### PR TITLE
56 docker compose seems to ignore alembic upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ docker compose up -d
 
 # Developing
 
-The suggested way of developing is with docker compose watch this allows for live reloading of changes. The liveload affects both frontend and backend.
+## Docker Compose
+To get changes made to the docker containers rebuild and deploy the images.
 
-## Live reload
 ```bash
-docker compose watch
+docker compose up --build --force-recreation
 ```
 
 ## Frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - 8080:8080
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     environment:
       DATABASE_CONNECTION_URL: postgresql://root:pass@database:5432/data
     networks: 
@@ -32,6 +33,12 @@ services:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: pass
       POSTGRES_DB: data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d data"]
+      interval: 10s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
     ports:
       - 5432:5432
     volumes:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,5 +9,4 @@ ENV HOST="0.0.0.0"
 ENV PORT="8080"
 ENV RELOAD="False"
 
-RUN alembic upgrade head
-CMD ["python", "src/main.py"]
+CMD bash -c "echo 'Starting alembic upgrade!' && alembic upgrade head && echo 'Starting python server!' && python src/main.py"


### PR DESCRIPTION
Fixed alembic only being run in creation.
Backend now waits for the database to be alive before starting.
Clarified documentation.