### PR TITLE
62 docker compose secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 __pycache__
 venv
 .venv
+
+#Secrets!
+secret_spotify_client_id.txt
+secret_spotify_client_secret.txt

--- a/README.md
+++ b/README.md
@@ -8,7 +8,14 @@ converted into an OSS project after the course ends.
 More info TBA.
 
 # Running the project
-The suggested way of running the project is with docker compose.
+The suggested way of running the project is with docker compose. This project uses secrets so you need to setup secret files.
+
+## Setup secrets
+Create files `secret_spotify_client_id.txt` and `secret_spotify_client_secret.txt` and fill them with spotify. You need to get these secrets from [Spotify](https://developer.spotify.com/dashboard). 
+See more about these secrets `server/README.md`.
+
+## Run
+To run the project after you have setup the secrets.
 
 ```bash
 docker compose up -d
@@ -16,6 +23,9 @@ docker compose up -d
 
 
 # Developing
+Set the same secrets files
+
+To see more about developing and running from `client/README.md` and `server/README.md`.
 
 ## Docker Compose
 To get changes made to the docker containers rebuild and deploy the images.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,16 @@ services:
       - 8080:8080
     depends_on:
       - database
-    environment:
-      DATABASE_CONNECTION_URL: postgresql://root:pass@database:5432/data
     networks: 
       - outgoing
       - internal
+    environment:
+      SPOTIFY_CLIENT_ID: /run/secrets/spotify_client_id
+      SPOTIFY_CLIENT_SECRET: /run/secrets/spotify_client_secret
+      DATABASE_CONNECTION_URL: postgresql://root:pass@database:5432/data
+    secrets:
+      - spotify_client_id
+      - spotify_client_secret
   database:
     image: postgres:latest
     restart: always
@@ -39,7 +44,11 @@ services:
     networks:
       - internal
 
-
+secrets:
+  spotify_client_id:
+    file: ./secret_spotify_client_id.txt
+  spotify_client_secret:
+    file: ./secret_spotify_client_secret.txt
 
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       - outgoing
       - internal
     environment:
-      SPOTIFY_CLIENT_ID: /run/secrets/spotify_client_id
-      SPOTIFY_CLIENT_SECRET: /run/secrets/spotify_client_secret
       DATABASE_CONNECTION_URL: postgresql://root:pass@database:5432/data
     secrets:
       - spotify_client_id

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -2,7 +2,21 @@ import os
 
 import uvicorn
 
+def InjectSecret(secret_name:str):
+    env_name = secret_name.upper()
+    with open(f"/run/secrets/{secret_name}") as secret_file:
+        secret = secret_file.read()
+        print(f"Setting envvar {env_name} from file {secret_name} as {secret}")
+        os.environ[env_name] = secret
+
+def InjectSecrets():
+    secret_files = ["spotify_client_id", "spotify_client_secret"]
+    
+    for secret_file in secret_files:
+        InjectSecret(secret_file)
+
 if __name__ == "__main__":
+    InjectSecrets()
     uvicorn.run("api.application:create_app",
                 host=os.getenv("HOST", default="127.0.0.1"),
                 port=int(os.getenv("PORT", default="8000")),


### PR DESCRIPTION
Added spotify secrets as secret files.

For some reason docker compose doesn't load secrets as env vars like it does in swarm mode so we inject the secrets at runtime. 