### PR TITLE
Removed .babelrc

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["@babel/preset-env", "@babel/preset-react"]
-  }


### PR DESCRIPTION
https://nextjs.org/docs/messages/babel-font-loader-conflict

Remove to fully use next.js compiler. This allows the usage of next/fonts.