### PR TITLE
Fix tests compiling without .babelrc

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["@babel/preset-env", "@babel/preset-react"]
-  }

--- a/client/jest.config.ts
+++ b/client/jest.config.ts
@@ -19,4 +19,54 @@ const config: Config = {
   testEnvironment: "jsdom",
 };
 
+module.exports = {
+  collectCoverage: true,
+  // on node 14.x coverage provider v8 offers good speed and more or less good report
+  coverageProvider: "v8",
+  collectCoverageFrom: [
+    "**/*.{js,jsx,ts,tsx}",
+    "!**/*.d.ts",
+    "!**/node_modules/**",
+    "!<rootDir>/out/**",
+    "!<rootDir>/.next/**",
+    "!<rootDir>/*.config.js",
+    "!<rootDir>/coverage/**",
+  ],
+  moduleNameMapper: {
+    // Handle CSS imports (with CSS modules)
+    // https://jestjs.io/docs/webpack#mocking-css-modules
+    "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
+
+    // Handle CSS imports (without CSS modules)
+    "^.+\\.(css|sass|scss)$": "<rootDir>/__mocks__/styleMock.js",
+
+    // Handle image imports
+    // https://jestjs.io/docs/webpack#handling-static-assets
+    "^.+\\.(png|jpg|jpeg|gif|webp|avif|ico|bmp|svg)$/i": `<rootDir>/__mocks__/fileMock.js`,
+
+    // Handle module aliases
+    "^@/components/(.*)$": "<rootDir>/components/$1",
+
+    // Handle @next/font
+    "@next/font/(.*)": `<rootDir>/__mocks__/nextFontMock.js`,
+    // Handle next/font
+    "next/font/(.*)": `<rootDir>/__mocks__/nextFontMock.js`,
+    // Disable server-only
+    "server-only": `<rootDir>/__mocks__/empty.js`,
+  },
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.next/"],
+  testEnvironment: "jsdom",
+  transform: {
+    // Use babel-jest to transpile tests with the next/babel preset
+    // https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object
+    "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
+  },
+  transformIgnorePatterns: [
+    "/node_modules/",
+    "^.+\\.module\\.(css|sass|scss)$",
+  ],
+};
+
 export default config;

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    output: "standalone",
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
Tests compile with babel instead of next.js compiler. Babel is used for testing because it seems to be a bit more accurate than v8. This can be changed if it affects performance too much by compiling with babel. 
Setting up Jest with Babel:
https://nextjs.org/docs/pages/building-your-application/testing/jest

Tradeoffs of v8 vs Babel
https://github.com/jestjs/jest/issues/11188