### PR TITLE
97 playlist handling in pool creation is broken

### DIFF
--- a/server/src/api/auth/dependencies.py
+++ b/server/src/api/auth/dependencies.py
@@ -77,8 +77,8 @@ class AuthSpotifyClientRaw:
             "Content-Type": "application/x-www-form-urlencoded"
         }
 
-        data = self._spotify_client.post("api/token", override_base_url="https://accounts.spotify.com/",
-                                         headers=headers, data=form)
+        data = self._spotify_client.post(override_url="https://accounts.spotify.com/api/token", headers=headers,
+                                         data=form)
         parsed_data = _validate_data(data)
         return SpotifyTokenResponse(access_token=parsed_data["access_token"], token_type=parsed_data["token_type"],
                                     expires_in=parsed_data["expires_in"], refresh_token=parsed_data["refresh_token"])

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -52,20 +52,20 @@ class SpotifyClientRaw:
     def __init__(self, request_client: RequestsClient):
         self._request_client = request_client
 
-    def get(self, query: str, *args, override_base_url: str = None, **kwargs) -> Response:
-        url = "https://api.spotify.com/v1/" if override_base_url is None else override_base_url
-        _logger.debug(f"Calling spotify API at GET {url}{query} with args: {args} and kwargs: {kwargs}")
-        return self._request_client.get(f"{url}{query}", *args, **kwargs)
+    def get(self, query: str = None, *args, override_url: str = None, **kwargs) -> Response:
+        query = f"https://api.spotify.com/v1/{query}" if override_url is None else override_url
+        _logger.debug(f"Calling spotify API at GET {query} with args: {args} and kwargs: {kwargs}")
+        return self._request_client.get(f"{query}", *args, **kwargs)
 
-    def post(self, query: str, *args, override_base_url: str = None, **kwargs) -> Response:
-        url = "https://api.spotify.com/v1/" if override_base_url is None else override_base_url
-        _logger.debug(f"Calling spotify API at POST {url}{query} with args: {args} and kwargs: {kwargs}")
-        return self._request_client.post(f"{url}{query}", *args, **kwargs)
+    def post(self, query: str = None, *args, override_url: str = None, **kwargs) -> Response:
+        query = f"https://api.spotify.com/v1/{query}" if override_url is None else override_url
+        _logger.debug(f"Calling spotify API at POST {query} with args: {args} and kwargs: {kwargs}")
+        return self._request_client.post(f"{query}", *args, **kwargs)
 
-    def put(self, query: str, *args, override_base_url: str = None, **kwargs) -> Response:
-        url = "https://api.spotify.com/v1/" if override_base_url is None else override_base_url
-        _logger.debug(f"Calling spotify API at PUT {url}{query} with args: {args} and kwargs: {kwargs}")
-        return self._request_client.put(f"{url}{query}", *args, **kwargs)
+    def put(self, query: str = None, *args, override_url: str = None, **kwargs) -> Response:
+        query = f"https://api.spotify.com/v1/{query}" if override_url is None else override_url
+        _logger.debug(f"Calling spotify API at PUT {query} with args: {args} and kwargs: {kwargs}")
+        return self._request_client.put(f"{query}", *args, **kwargs)
 
 
 SpotifyClient = Annotated[SpotifyClientRaw, Depends()]

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -96,7 +96,7 @@ class PoolSpotifyClientRaw:
     def _fetch_playlist(self, token: str, playlist_id: str) -> PoolCollection:
         raw_playlist_data = self._spotify_client.get(f"playlists/{playlist_id}", headers=_auth_header(token))
         playlist_data = json.loads(raw_playlist_data.content.decode("utf-8"))
-        tracks = _build_tracks_without_image(playlist_data["tracks"]["items"])
+        tracks = _build_tracks_without_image([track["track"] for track in playlist_data["tracks"]["items"]])
         return PoolCollection(name=playlist_data["name"], spotify_icon_uri=get_sharpest_icon(playlist_data["images"]),
                               tracks=tracks, spotify_collection_uri=playlist_data["uri"])
 

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -94,11 +94,24 @@ class PoolSpotifyClientRaw:
                               tracks=tracks, spotify_collection_uri=artist_data["uri"])
 
     def _fetch_playlist(self, token: str, playlist_id: str) -> PoolCollection:
-        raw_playlist_data = self._spotify_client.get(f"playlists/{playlist_id}", headers=_auth_header(token))
-        playlist_data = json.loads(raw_playlist_data.content.decode("utf-8"))
+        playlist_data = self._fully_fetch_playlist(playlist_id, token)
         tracks = _build_tracks_without_image([track["track"] for track in playlist_data["tracks"]["items"]])
         return PoolCollection(name=playlist_data["name"], spotify_icon_uri=get_sharpest_icon(playlist_data["images"]),
                               tracks=tracks, spotify_collection_uri=playlist_data["uri"])
+
+    def _fully_fetch_playlist(self, playlist_id, token):
+        raw_playlist_data = self._spotify_client.get(f"playlists/{playlist_id}", headers=_auth_header(token))
+        playlist_data = json.loads(raw_playlist_data.content.decode("utf-8"))
+        if playlist_data["tracks"]["next"] is not None:
+            self._fetch_large_playlist_tracks(playlist_data, token)
+        return playlist_data
+
+    def _fetch_large_playlist_tracks(self, playlist_data, token: str):
+        track_walker = playlist_data["tracks"]
+        while track_walker["next"] is not None:
+            raw_next_track_data = self._spotify_client.get(override_url=track_walker["next"])
+            track_walker = json.loads(raw_next_track_data.content.decode("utf-8"))
+            playlist_data["tracks"]["items"].extend(track_walker["items"])
 
     def start_playback(self, token: str, track_uri: str):
         header = _auth_header(token)

--- a/server/test/pool_features/add_content_features.py
+++ b/server/test/pool_features/add_content_features.py
@@ -50,13 +50,12 @@ def should_preserve_existing_pool_members_on_new_member_addition(create_mock_tra
     assert len(actual_pool_content) == len(existing_pool) + 1
 
 
-def should_correctly_construct_pool_after_collection_addition(create_mock_track_search_result, requests_client,
+def should_correctly_construct_pool_after_collection_addition(requests_client,
                                                               build_success_response, test_client,
                                                               valid_token_header, db_connection, logged_in_user_id,
-                                                              existing_pool, create_mock_playlist_search_result,
+                                                              existing_pool, create_mock_playlist_fetch_result,
                                                               validate_response):
-    tracks = [create_mock_track_search_result() for _ in range(35)]
-    playlist = create_mock_playlist_search_result(tracks)
+    playlist = create_mock_playlist_fetch_result(35)
     requests_client.get = Mock(return_value=build_success_response(playlist))
     pool_content_data = PoolContent(spotify_uri=playlist["uri"]).model_dump()
 
@@ -67,7 +66,7 @@ def should_correctly_construct_pool_after_collection_addition(create_mock_track_
             and_(PoolMember.user_id == logged_in_user_id, PoolMember.parent_id == None))).unique().all()
     assert len(actual_pool_content) == len(existing_pool) + 1
     pool_response = validate_response(response)
-    assert len(pool_response["collections"][0]["tracks"]) == len(tracks)
+    assert len(pool_response["collections"][0]["tracks"]) == len(playlist["tracks"]["items"])
 
 
 def should_use_collection_icon_as_track_icon_on_collection_addition(create_mock_track_search_result, requests_client,

--- a/server/test/pool_features/conftest.py
+++ b/server/test/pool_features/conftest.py
@@ -1,3 +1,4 @@
+import datetime
 import random
 from unittest.mock import Mock
 
@@ -31,3 +32,75 @@ def existing_pool(create_mock_track_search_result, build_success_response, reque
     with db_connection.session() as session:
         members = session.scalars(select(PoolMember).where(PoolMember.user_id == logged_in_user_id)).unique().all()
     return members
+
+
+@pytest.fixture
+def create_mock_playlist_fetch_result(create_mock_track_search_result, faker):
+    def wrapper(track_amount: int):
+        user = faker.name().replace(" ", "")
+        playlist_id = faker.uuid4()
+        tracks = [create_mock_track_search_result() for _ in range(track_amount)]
+        playlist_tracks = []
+        for track in tracks:
+            playlist_tracks.append({
+                "added_at": datetime.datetime.strftime(datetime.datetime.now(), "%Y-%m-%dT%H:%M:%SZ"),
+                "added_by": {
+                    "external_urls": {
+                        "spotify": f"https://fake.spotify.com/users/{user}"
+                    },
+                    "href": f"https://api.spotify.fake/v1/users/{user}",
+                    "id": user,
+                    "type": "user",
+                    "uri": f"spotify:user:{user}"
+                },
+                "is_local": False,
+                "track": track
+            })
+        playlist_data = {
+            "collaborative": False,
+            "description": faker.paragraph(),
+            "external_urls": {
+                "spotify": f"https://fake.spotify.fake/playlist/{playlist_id}"
+            },
+            "followers": {
+                "href": None,
+                "total": random.randint(0, 9999)
+            },
+            "href": f"https://api.spotify.fake/v1/playlists/{playlist_id}?locale=en",
+            "id": playlist_id,
+            "images": [
+                {
+                    "url": f"https://image-cdn-fa.spotifycdn.fake/image/{faker.uuid4()}",
+                    "height": None,
+                    "width": None
+                }
+            ],
+            "name": faker.text(max_nb_chars=25)[:-1],
+            "owner": {
+                "external_urls": {
+                    "spotify": f"https://fake.spotify.com/users/{user}"
+                },
+                "href": f"https://api.spotify.fake/v1/users/{user}",
+                "id": user,
+                "type": "user",
+                "uri": f"spotify:user:{user}",
+                "display_name": user
+            },
+            "public": True,
+            "snapshot_id": faker.uuid4(),
+            "tracks": {
+                "href": f"https://api.spotify.fake/v1/playlists/{playlist_id}/tracks?offset=0&limit=100&locale=en",
+                "limit": 100,
+                "next": None if track_amount < 100 else f"https://api.spotify.fake/v1/playlists/{playlist_id}/"
+                                                        f"tracks?offset=100&limit=100&locale=en",
+                "offset": 0,
+                "previous": None,
+                "total": track_amount,
+                "items": playlist_tracks[:100]
+            },
+            "type": "playlist",
+            "uri": f"spotify:playlist:{playlist_id}"
+        }
+
+        return playlist_data
+    return wrapper

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -130,11 +130,10 @@ def should_save_artist_top_ten_tracks_as_pool_in_database(test_client: TestClien
 
 
 def should_be_able_to_create_pool_from_playlist(test_client: TestClient, valid_token_header,
-                                                create_mock_playlist_search_result, validate_response,
+                                                create_mock_playlist_fetch_result, validate_response,
                                                 create_mock_track_search_result, build_success_response,
                                                 requests_client, create_pool_creation_data_json):
-    tracks = [create_mock_track_search_result() for _ in range(30)]
-    playlist = create_mock_playlist_search_result(tracks)
+    playlist = create_mock_playlist_fetch_result(30)
     requests_client.get = Mock(return_value=build_success_response(playlist))
     data_json = create_pool_creation_data_json(playlist["uri"])
 
@@ -144,17 +143,17 @@ def should_be_able_to_create_pool_from_playlist(test_client: TestClient, valid_t
                                            headers={"Authorization": valid_token_header["token"]})
     pool_response = validate_response(result)
     assert pool_response["tracks"] == []
-    assert len(pool_response["collections"][0]["tracks"]) == len(tracks)
-    for expected_track, actual_track in zip(tracks, pool_response["collections"][0]["tracks"]):
+    expected_tracks = [track["track"] for track in playlist["tracks"]["items"]]
+    assert len(pool_response["collections"][0]["tracks"]) == len(expected_tracks)
+    for expected_track, actual_track in zip(expected_tracks, pool_response["collections"][0]["tracks"]):
         assert actual_track["name"] == expected_track["name"]
 
 
 def should_save_whole_playlist_as_pool_in_database(test_client: TestClient, valid_token_header, db_connection,
-                                                   create_mock_playlist_search_result, create_mock_track_search_result,
+                                                   create_mock_playlist_fetch_result, create_mock_track_search_result,
                                                    build_success_response, requests_client,
                                                    create_pool_creation_data_json, logged_in_user_id):
-    tracks = [create_mock_track_search_result() for _ in range(30)]
-    playlist = create_mock_playlist_search_result(tracks)
+    playlist = create_mock_playlist_fetch_result(30)
     requests_client.get = Mock(return_value=build_success_response(playlist))
     data_json = create_pool_creation_data_json(playlist["uri"])
 
@@ -165,8 +164,9 @@ def should_save_whole_playlist_as_pool_in_database(test_client: TestClient, vali
             and_(PoolMember.user_id == logged_in_user_id, PoolMember.parent_id == None))
                                            .options(joinedload(PoolMember.children)))
     assert actual_parent.name == playlist["name"]
-    assert len(actual_parent.children) == len(tracks)
-    for expected_track, actual_track in zip(tracks, sorted(actual_parent.children, key=lambda x: x.sort_order)):
+    expected_tracks = [track["track"] for track in playlist["tracks"]["items"]]
+    assert len(actual_parent.children) == len(expected_tracks)
+    for expected_track, actual_track in zip(expected_tracks, sorted(actual_parent.children, key=lambda x: x.sort_order)):
         assert actual_track.name == expected_track["name"]
         assert actual_track.duration_ms == expected_track["duration_ms"]
 
@@ -203,12 +203,12 @@ def should_be_able_to_post_multiple_pool_members_on_creation(test_client: TestCl
                                                              create_pool_creation_data_json, db_connection,
                                                              create_mock_artist_search_result,
                                                              create_mock_album_search_result, logged_in_user_id,
-                                                             create_mock_playlist_search_result):
+                                                             create_mock_playlist_fetch_result):
     tracks = [create_mock_track_search_result() for _ in range(10)]
     artist = create_mock_artist_search_result()
     artist_tracks = {"tracks": [create_mock_track_search_result(artist) for _ in range(10)]}
     album = create_mock_album_search_result(artist, [create_mock_track_search_result(artist) for _ in range(12)])
-    playlist = create_mock_playlist_search_result([create_mock_track_search_result() for _ in range(23)])
+    playlist = create_mock_playlist_fetch_result(23)
     responses = [build_success_response(track) for track in tracks]
     responses.extend([build_success_response(artist), build_success_response(artist_tracks),
                       build_success_response(album), build_success_response(playlist)])

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -229,7 +229,6 @@ def should_be_able_to_post_multiple_pool_members_on_creation(test_client: TestCl
         assert len(actual_results) == len(tracks) + 3
 
 
-@pytest.mark.wip
 def should_fetch_multiple_times_if_playlist_is_too_long_to_fetch_in_one_go(test_client: TestClient, valid_token_header,
                                                                            db_connection, requests_client,
                                                                            create_mock_playlist_fetch_result,

--- a/server/test/pool_features/delete_content_features.py
+++ b/server/test/pool_features/delete_content_features.py
@@ -23,33 +23,32 @@ def should_not_have_track_in_database_after_deletion(existing_pool: list[PoolMem
 
 
 def should_be_able_to_delete_separate_child_from_collection(create_mock_track_search_result, test_client, db_connection,
-                                                            create_mock_playlist_search_result, validate_response,
+                                                            create_mock_playlist_fetch_result, validate_response,
                                                             logged_in_user_id, valid_token_header,
                                                             create_pool_creation_data_json, requests_client,
                                                             build_success_response):
-    tracks = [create_mock_track_search_result() for _ in range(15)]
-    playlist = create_mock_playlist_search_result(tracks)
+    playlist = create_mock_playlist_fetch_result(15)
+    expected_tracks = [track["track"] for track in playlist["tracks"]["items"]]
     requests_client.get = Mock(return_value=build_success_response(playlist))
     test_client.post("/pool", json=create_pool_creation_data_json(playlist["uri"]), headers=valid_token_header)
 
-    response = test_client.delete(f"/pool/content/{tracks[5]["uri"]}", headers=valid_token_header)
+    response = test_client.delete(f"/pool/content/{expected_tracks[5]["uri"]}", headers=valid_token_header)
     pool_response = validate_response(response)
-    assert len(pool_response["collections"][0]["tracks"]) == len(tracks) - 1
+    assert len(pool_response["collections"][0]["tracks"]) == len(expected_tracks) - 1
     with db_connection.session() as session:
         all_tracks = session.scalars(select(PoolMember).where(
             and_(PoolMember.parent_id != None, PoolMember.user_id == logged_in_user_id))).unique().all()
-    assert len(all_tracks) == len(tracks) - 1
+    assert len(all_tracks) == len(expected_tracks) - 1
     with db_connection.session() as session:
         parent = session.scalar(select(PoolMember).where(PoolMember.content_uri == playlist["uri"]))
     assert parent is not None
 
 
 def should_delete_all_children_on_parent_deletion(create_mock_track_search_result, test_client, db_connection,
-                                                  create_mock_playlist_search_result, validate_response,
+                                                  create_mock_playlist_fetch_result, validate_response,
                                                   logged_in_user_id, valid_token_header, create_pool_creation_data_json,
                                                   requests_client, build_success_response):
-    tracks = [create_mock_track_search_result() for _ in range(15)]
-    playlist = create_mock_playlist_search_result(tracks)
+    playlist = create_mock_playlist_fetch_result(15)
     requests_client.get = Mock(return_value=build_success_response(playlist))
     test_client.post("/pool", json=create_pool_creation_data_json(playlist["uri"]), headers=valid_token_header)
 

--- a/server/test/pool_features/get_pool_features.py
+++ b/server/test/pool_features/get_pool_features.py
@@ -14,11 +14,11 @@ def should_return_mix_of_tracks_and_collections_correctly(test_client, valid_tok
                                                           create_mock_track_search_result, build_success_response,
                                                           requests_client, create_mock_artist_search_result,
                                                           create_mock_album_search_result, existing_pool,
-                                                          create_mock_playlist_search_result):
+                                                          create_mock_playlist_fetch_result):
     artist = create_mock_artist_search_result()
     artist_tracks = {"tracks": [create_mock_track_search_result(artist) for _ in range(10)]}
     album = create_mock_album_search_result(artist, [create_mock_track_search_result(artist) for _ in range(12)])
-    playlist = create_mock_playlist_search_result([create_mock_track_search_result() for _ in range(23)])
+    playlist = create_mock_playlist_fetch_result(23)
     responses = [build_success_response(artist), build_success_response(artist_tracks), build_success_response(album),
                  build_success_response(playlist)]
     requests_client.get = Mock(side_effect=responses)


### PR DESCRIPTION
Two problems fixed:

1. We were handling playlist data incorrectly when fetching from spotify playlist GET endpoint instead of general search. The endpoint returns a deeper data structure with extra metadata for each playlist track inserted in the middle. Modified relevant tests to accomodate this and fixed handling.
2. Spotify only sends the first 100 songs of a playlist on fetch. Made a test for fetching all iteratively and implemented functionality.