### PR TITLE
103 Make track data use artist data on backend

### DIFF
--- a/server/src/api/search/dependencies.py
+++ b/server/src/api/search/dependencies.py
@@ -10,17 +10,25 @@ from api.common.models import NamedResource
 from api.search.models import Track, Album, Artist, Playlist, PaginatedSearchResult, GeneralSearchResult, \
     SpotifyPlayableType, ArtistSearchResult, AlbumSearchResult, TrackSearchResult, PlaylistSearchResult
 
-
 _logger = getLogger("main.api.search.dependencies")
 
 
 def _build_track(track_data: dict) -> Track:
+    album_artists = [NamedResource(name=artist["name"], link=artist["href"]) for artist in
+                     track_data["album"]["artists"]]
     return Track(
-        artists=[NamedResource(name=artist["name"], link=artist["href"]) for artist in track_data["artists"]],
-        album=NamedResource(name=track_data["album"]["name"], link=track_data["album"]["href"]),
+        artists=[NamedResource(name=artist["name"], link=artist["href"])
+                 for artist in track_data["artists"]],
+        album=Album(name=track_data["album"]["name"],
+                    uri=track_data["album"]["uri"],
+                    artists=album_artists,
+                    icon_link=get_sharpest_icon(track_data["album"]["images"]),
+                    year=int(track_data["album"]["release_date"][:4]),
+                    link=track_data["album"]["href"]),
         duration_ms=track_data["duration_ms"],
         name=track_data["name"],
-        uri=track_data["uri"]
+        uri=track_data["uri"],
+        link=track_data["href"]
     )
 
 
@@ -39,7 +47,8 @@ def _build_artist(artist_data: dict) -> Artist:
     return Artist(
         name=artist_data["name"],
         uri=artist_data["uri"],
-        icon_link=get_sharpest_icon(artist_data["images"])
+        icon_link=get_sharpest_icon(artist_data["images"]),
+        link=artist_data["href"]
     )
 
 
@@ -60,7 +69,8 @@ def _build_album(album_data: dict) -> Album:
         year=int(album_data["release_date"][:4]),
         icon_link=get_sharpest_icon(album_data["images"]),
         name=album_data["name"],
-        uri=album_data["uri"]
+        uri=album_data["uri"],
+        link=album_data["href"]
     )
 
 
@@ -79,7 +89,8 @@ def _build_playlist(playlist_data: dict) -> Playlist:
     return Playlist(
         name=playlist_data["name"],
         uri=playlist_data["uri"],
-        icon_link=get_sharpest_icon(playlist_data["images"])
+        icon_link=get_sharpest_icon(playlist_data["images"]),
+        link=playlist_data["href"]
     )
 
 

--- a/server/src/api/search/models.py
+++ b/server/src/api/search/models.py
@@ -13,15 +13,12 @@ class SpotifyPlayableType(Enum):
     Playlist = "playlist"
 
 
-class SpotifyPlayable(BaseModel):
-    name: str
+class SpotifyPlayable(NamedResource):
     uri: str  # spotify unique uri: spotify:track:4PTG3Z6ehGkBFwjybzWkR8
 
 
-class Track(SpotifyPlayable):
-    artists: list[NamedResource]
-    album: NamedResource
-    duration_ms: int
+class Artist(SpotifyPlayable):
+    icon_link: str
 
 
 class Album(SpotifyPlayable):
@@ -30,8 +27,10 @@ class Album(SpotifyPlayable):
     icon_link: str
 
 
-class Artist(SpotifyPlayable):
-    icon_link: str
+class Track(SpotifyPlayable):
+    artists: list[NamedResource]
+    album: Album
+    duration_ms: int
 
 
 class Playlist(SpotifyPlayable):


### PR DESCRIPTION
Could not fully unify the models as spotify doesn't return as much artist data on track search as they do on artist search. However, massaged some models so now we have:

- Full album data for returned tracks
 - This can be used to get icon for tracks anywhere
- Link to spotify (href) for every search result. This should be later used in frontend to adhere to spotify external developer standards.