### PR TITLE
94 create core routes for sharing and joining pools

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,3 +6,4 @@ alembic==1.13.1
 psycopg2==2.9.9
 requests==2.31.0
 APScheduler==3.10.4
+websockets==12.0

--- a/server/src/alembic/versions/70e02357c5ff_big_changes_for_support_for_pool_.py
+++ b/server/src/alembic/versions/70e02357c5ff_big_changes_for_support_for_pool_.py
@@ -1,0 +1,64 @@
+"""Big changes for support for pool joining and future proofing data structures
+
+Revision ID: 70e02357c5ff
+Revises: 27048d682757
+Create Date: 2024-03-22 22:58:29.691236
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '70e02357c5ff'
+down_revision: Union[str, None] = '27048d682757'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('Pool',
+                    sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+                    sa.Column('name', sa.String(length=32), nullable=True),
+                    sa.Column('owner_user_id', sa.String(length=64), nullable=False),
+                    sa.Column('insert_time_stamp', sa.DateTime(), nullable=False),
+                    sa.ForeignKeyConstraint(['owner_user_id'], ['User.spotify_id'], ),
+                    sa.PrimaryKeyConstraint('id')
+                    )
+    op.create_table('UserSession',
+                    sa.Column('user_id', sa.String(length=64), nullable=False),
+                    sa.Column('user_token', sa.String(length=512), nullable=False),
+                    sa.Column('refresh_token', sa.String(length=512), nullable=False),
+                    sa.Column('expires_at', sa.DateTime(), nullable=False),
+                    sa.Column('insert_time_stamp', sa.DateTime(), nullable=False),
+                    sa.ForeignKeyConstraint(['user_id'], ['User.spotify_id'], ),
+                    sa.PrimaryKeyConstraint('user_id')
+                    )
+    op.create_table('PoolJoinedUser',
+                    sa.Column('user_id', sa.String(length=64), nullable=False),
+                    sa.Column('pool_id', sa.Integer(), nullable=False),
+                    sa.Column('insert_time_stamp', sa.DateTime(), nullable=False),
+                    sa.ForeignKeyConstraint(['pool_id'], ['Pool.id'], onupdate='CASCADE', ondelete='CASCADE'),
+                    sa.ForeignKeyConstraint(['user_id'], ['User.spotify_id'], ),
+                    sa.PrimaryKeyConstraint('user_id')
+                    )
+    op.create_table('PoolShareData',
+                    sa.Column('pool_id', sa.Integer(), nullable=False),
+                    sa.Column('code', sa.String(length=8), nullable=False),
+                    sa.Column('insert_time_stamp', sa.DateTime(), nullable=False),
+                    sa.ForeignKeyConstraint(['pool_id'], ['Pool.id'], onupdate='CASCADE', ondelete='CASCADE'),
+                    sa.PrimaryKeyConstraint('pool_id')
+                    )
+    op.add_column('PoolMember', sa.Column('pool_id', sa.Integer(), nullable=False))
+    op.create_foreign_key("PoolMember_pool_id_fkey", 'PoolMember', 'Pool', ['pool_id'], ['id'], onupdate='CASCADE', ondelete='CASCADE')
+
+
+def downgrade() -> None:
+    op.drop_constraint("PoolMember_pool_id_fkey", 'PoolMember', type_='foreignkey')
+    op.drop_column('PoolMember', 'pool_id')
+    op.drop_table('PoolShareData')
+    op.drop_table('PoolJoinedUser')
+    op.drop_table('UserSession')
+    op.drop_table('Pool')

--- a/server/src/api/auth/dependencies.py
+++ b/server/src/api/auth/dependencies.py
@@ -2,8 +2,6 @@ import base64
 import datetime
 import json
 import os
-import random
-import string
 from logging import getLogger
 from typing import Annotated
 
@@ -13,6 +11,7 @@ from sqlalchemy import delete, select
 
 from api.auth.models import SpotifyTokenResponse, LoginRedirect, LoginSuccess
 from api.common.dependencies import DatabaseConnection, SpotifyClient, TokenHolder
+from api.common.helpers import create_random_string
 from api.common.models import ParsedTokenResponse
 from database.entities import LoginState, User, UserSession
 
@@ -109,11 +108,6 @@ _required_scopes = [
 ]
 
 
-def _create_random_string(length: int) -> str:
-    chars = string.ascii_letters + string.digits
-    return "".join(random.choice(chars) for _ in range(length))
-
-
 class AuthServiceRaw:
 
     def __init__(self, spotify_client: AuthSpotifyClient, database_connection: AuthDatabaseConnection,
@@ -125,7 +119,7 @@ class AuthServiceRaw:
     def build_redirect(self, client_redirect_uri: str) -> LoginRedirect:
         base_url = "https://accounts.spotify.com/authorize?"
         scopes_string = " ".join(_required_scopes)
-        state = _create_random_string(16)
+        state = create_random_string(16)
         self._database_connection.save_state(state)
         client_id = os.getenv("SPOTIFY_CLIENT_ID", default=None)
         if client_id is None:

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -102,17 +102,14 @@ class TokenHolderRaw:
     def __init__(self, user_database_connection: UserDatabaseConnection):
         self._user_database_connection = user_database_connection
 
-    def validate_token(self, token: str) -> User:
+    def get_user_from_token(self, token: str) -> User:
         user = self._user_database_connection.get_from_token(token)
         if user is None:
             _logger.error(f"Token {token} not found.")
             raise HTTPException(status_code=403, detail="Invalid bearer token!")
         return user
 
-    def get_from_token(self, token: str) -> User:
-        return self._user_database_connection.get_from_token(token)
-
-    def get_from_user_id(self, user_id: str) -> User:
+    def get_user_from_user_id(self, user_id: str) -> User:
         return self._user_database_connection.get_from_id(user_id)
 
     def log_out(self, token: str):
@@ -129,8 +126,8 @@ TokenHolder = Annotated[TokenHolderRaw, Depends()]
 
 
 def validated_user_raw(token: Annotated[str, Header()], token_holder: TokenHolder) -> User:
-    _logger.debug(f"Validating token {token}")
-    user = token_holder.validate_token(token)
+    _logger.debug(f"Getting user for token {token}")
+    user = token_holder.get_user_from_token(token)
     return user
 
 

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -97,7 +97,7 @@ class UserDatabaseConnectionRaw:
 
     def log_out(self, token: str):
         with self._database_connection.session() as session:
-            user = session.scalar(select(User).where(User.session.user_token == token))
+            user = session.scalar(select(User).where(User.session.has(UserSession.user_token == token)))
             session.delete(user.session)
 
 
@@ -132,7 +132,7 @@ class TokenHolderRaw:
         return self._user_database_connection.get_from_token(token) is not None
 
     def is_user_logged_in(self, user_id: str):
-        return self._user_database_connection.get_from_id(user_id) is not None
+        return self._user_database_connection.get_from_id(user_id).session is not None
 
 
 TokenHolder = Annotated[TokenHolderRaw, Depends()]

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -1,3 +1,4 @@
+import datetime
 import functools
 from logging import getLogger
 from typing import Annotated
@@ -5,10 +6,11 @@ from typing import Annotated
 import requests
 from fastapi import Depends, HTTPException, Header
 from requests import Response
+from sqlalchemy import select, and_
 
+from api.common.models import ParsedTokenResponse
 from database.database_connection import ConnectionManager
-from database.entities import User
-
+from database.entities import User, UserSession
 
 _logger = getLogger("main.api.common.dependencies")
 
@@ -70,48 +72,76 @@ class SpotifyClientRaw:
 
 SpotifyClient = Annotated[SpotifyClientRaw, Depends()]
 
-
 DatabaseConnection = Annotated[ConnectionManager, Depends()]
+
+
+class UserDatabaseConnectionRaw:
+
+    def __init__(self, database_connection: DatabaseConnection):
+        self._database_connection = database_connection
+
+    def log_in(self, token: ParsedTokenResponse, user: User):
+        with self._database_connection.session() as session:
+            user.session = UserSession(user_token=token.token, refresh_token=token.refresh_token,
+                                       expires_at=datetime.datetime.now() + datetime.timedelta(
+                                           seconds=token.expires_in))
+            session.merge(user)
+
+    def get_from_token(self, token: str) -> User | None:
+        with self._database_connection.session() as session:
+            return session.scalar(select(User).where(User.session.has(UserSession.user_token == token)))
+
+    def get_from_id(self, user_id: str) -> User | None:
+        with self._database_connection.session() as session:
+            return session.scalar(select(User).where(User.spotify_id == user_id))
+
+    def log_out(self, token: str):
+        with self._database_connection.session() as session:
+            user = session.scalar(select(User).where(User.session.user_token == token))
+            session.delete(user.session)
+
+
+UserDatabaseConnection = Annotated[UserDatabaseConnectionRaw, Depends()]
 
 
 class TokenHolderRaw:
 
-    _tokens: dict[str, User] = {}
-    _user_tokens: dict[str, str] = {}
+    def __init__(self, user_database_connection: UserDatabaseConnection):
+        self._user_database_connection = user_database_connection
 
-    def add_token(self, token: str, user: User):
-        self._tokens[token] = user
-        self._user_tokens[user.spotify_id] = token
+    def log_in(self, token: ParsedTokenResponse, user: User):
+        self._user_database_connection.log_in(token, user)
 
-    def validate_token(self, token: str):
-        if not self.is_token_logged_in(token):
-            _logger.error(f"Token {token} not found in {self._tokens}")
+    def validate_token(self, token: str) -> User:
+        user = self._user_database_connection.get_from_token(token)
+        if user is None:
+            _logger.error(f"Token {token} not found.")
             raise HTTPException(status_code=403, detail="Invalid bearer token!")
+        return user
 
     def get_from_token(self, token: str) -> User:
-        return self._tokens[token]
+        return self._user_database_connection.get_from_token(token)
 
-    def get_from_user_id(self, user_id: str) -> str:
-        return self._user_tokens[user_id]
+    def get_from_user_id(self, user_id: str) -> User:
+        return self._user_database_connection.get_from_id(user_id)
 
     def log_out(self, token: str):
-        user_id = self._tokens.pop(token).spotify_id
-        self._user_tokens.pop(user_id)
+        self._user_database_connection.log_out(token)
 
     def is_token_logged_in(self, token: str):
-        return token in self._tokens
+        return self._user_database_connection.get_from_token(token) is not None
 
     def is_user_logged_in(self, user_id: str):
-        return user_id in self._user_tokens
+        return self._user_database_connection.get_from_id(user_id) is not None
 
 
 TokenHolder = Annotated[TokenHolderRaw, Depends()]
 
 
-def validated_token_raw(token: Annotated[str, Header()], token_holder: TokenHolder):
+def validated_user_raw(token: Annotated[str, Header()], token_holder: TokenHolder) -> User:
     _logger.debug(f"Validating token {token}")
-    token_holder.validate_token(token)
-    return token
+    user = token_holder.validate_token(token)
+    return user
 
 
-validated_token = Annotated[str, Depends(validated_token_raw)]
+validated_user = Annotated[User, Depends(validated_user_raw)]

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -80,13 +80,6 @@ class UserDatabaseConnectionRaw:
     def __init__(self, database_connection: DatabaseConnection):
         self._database_connection = database_connection
 
-    def log_in(self, token: ParsedTokenResponse, user: User):
-        with self._database_connection.session() as session:
-            user.session = UserSession(user_token=token.token, refresh_token=token.refresh_token,
-                                       expires_at=datetime.datetime.now() + datetime.timedelta(
-                                           seconds=token.expires_in))
-            session.merge(user)
-
     def get_from_token(self, token: str) -> User | None:
         with self._database_connection.session() as session:
             return session.scalar(select(User).where(User.session.has(UserSession.user_token == token)))
@@ -108,9 +101,6 @@ class TokenHolderRaw:
 
     def __init__(self, user_database_connection: UserDatabaseConnection):
         self._user_database_connection = user_database_connection
-
-    def log_in(self, token: ParsedTokenResponse, user: User):
-        self._user_database_connection.log_in(token, user)
 
     def validate_token(self, token: str) -> User:
         user = self._user_database_connection.get_from_token(token)

--- a/server/src/api/common/helpers.py
+++ b/server/src/api/common/helpers.py
@@ -1,3 +1,5 @@
+import random
+import string
 from logging import getLogger
 
 from api.common.models import UserModel
@@ -27,3 +29,8 @@ def build_auth_header(user: User) -> dict:
     return {
         "Authorization": user.session.user_token
     }
+
+
+def create_random_string(length: int) -> str:
+    chars = string.ascii_letters + string.digits
+    return "".join(random.choice(chars) for _ in range(length))

--- a/server/src/api/common/helpers.py
+++ b/server/src/api/common/helpers.py
@@ -1,5 +1,8 @@
 from logging import getLogger
 
+from api.common.models import UserModel
+from database.entities import User
+
 _logger = getLogger("main.api.common.helpers")
 
 
@@ -13,3 +16,8 @@ def get_sharpest_icon(icons: list[dict]) -> str:
             biggest_icon = icon["url"]
     _logger.debug(f"Found icon with height {max_size} and url '{biggest_icon}'")
     return biggest_icon
+
+
+def map_user_entity_to_model(user_entity: User) -> UserModel:
+    return UserModel(display_name=user_entity.spotify_username, icon_url=user_entity.spotify_avatar_url,
+                     spotify_id=user_entity.spotify_id)

--- a/server/src/api/common/helpers.py
+++ b/server/src/api/common/helpers.py
@@ -21,3 +21,9 @@ def get_sharpest_icon(icons: list[dict]) -> str:
 def map_user_entity_to_model(user_entity: User) -> UserModel:
     return UserModel(display_name=user_entity.spotify_username, icon_url=user_entity.spotify_avatar_url,
                      spotify_id=user_entity.spotify_id)
+
+
+def build_auth_header(user: User) -> dict:
+    return {
+        "Authorization": user.session.user_token
+    }

--- a/server/src/api/common/models.py
+++ b/server/src/api/common/models.py
@@ -4,3 +4,15 @@ from pydantic import BaseModel
 class NamedResource(BaseModel):
     name: str
     link: str
+
+
+class UserModel(BaseModel):
+    display_name: str
+    icon_url: str | None
+    spotify_id: str
+
+
+class ParsedTokenResponse(BaseModel):
+    token: str
+    refresh_token: str
+    expires_in: int

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -167,8 +167,9 @@ def _get_user_pool(user: User, session: Session) -> list[PoolMember]:
 
 def _get_playable_tracks(user: User, session: Session) -> list[PoolMember]:
     _logger.debug(f"Getting playable tracks for user {user.spotify_username}")
+    pool = _get_pool_for_user(user, session)
     return list(session.scalars(select(PoolMember).where(
-        and_(PoolMember.user_id == user.spotify_id, PoolMember.content_uri.like("spotify:track:%")))).unique().all())
+        and_(PoolMember.pool_id == pool.id, PoolMember.content_uri.like("spotify:track:%")))).unique().all())
 
 
 def _delete_pool_member(content_uri: str, user: User, session: Session):

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -340,7 +340,7 @@ class PoolPlaybackServiceRaw:
         if not self._token_holder.is_user_logged_in(playback.user_id):
             self._database_connection.set_playback_as_inactive(playback)
             return
-        user = self._token_holder.get_from_user_id(playback.user_id)
+        user = self._token_holder.get_user_from_user_id(playback.user_id)
         self._queue_next_song(user)
 
     def _queue_next_song(self, user: User, override_timestamp: bool = False) -> PoolMember:

--- a/server/src/api/pool/helpers.py
+++ b/server/src/api/pool/helpers.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from api.pool.models import Pool, PoolTrack, PoolCollection
+from api.pool.models import PoolFullContents, PoolTrack, PoolCollection
 from database.entities import PoolMember
 
 
@@ -15,7 +15,7 @@ def _create_collection_tracks(collection: PoolMember) -> list[PoolTrack]:
             for track in collection.children]
 
 
-def create_pool_return_model(pool: list[PoolMember]) -> Pool:
+def create_pool_return_model(pool: list[PoolMember]) -> PoolFullContents:
     _logger.debug(f"Creating pool return model from {len(pool)} members.")
     tracks = []
     collections = []
@@ -27,4 +27,4 @@ def create_pool_return_model(pool: list[PoolMember]) -> Pool:
             collections.append(PoolCollection(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
                                               tracks=_create_collection_tracks(pool_member),
                                               spotify_collection_uri=pool_member.content_uri))
-    return Pool(tracks=tracks, collections=collections)
+    return PoolFullContents(tracks=tracks, collections=collections)

--- a/server/src/api/pool/helpers.py
+++ b/server/src/api/pool/helpers.py
@@ -1,8 +1,8 @@
 from logging import getLogger
 
-from api.pool.models import PoolFullContents, PoolTrack, PoolCollection
-from database.entities import PoolMember
-
+from api.common.helpers import map_user_entity_to_model
+from api.pool.models import PoolFullContents, PoolTrack, PoolCollection, PoolUserContents
+from database.entities import PoolMember, User
 
 _logger = getLogger("main.api.pool.helpers")
 
@@ -15,16 +15,20 @@ def _create_collection_tracks(collection: PoolMember) -> list[PoolTrack]:
             for track in collection.children]
 
 
-def create_pool_return_model(pool: list[PoolMember]) -> PoolFullContents:
+def create_pool_return_model(pool: list[PoolMember], users: list[User]) -> PoolFullContents:
     _logger.debug(f"Creating pool return model from {len(pool)} members.")
-    tracks = []
-    collections = []
+    users_map = {user.spotify_id: PoolUserContents(tracks=[],
+                                                   collections=[],
+                                                   user=map_user_entity_to_model(user))
+                 for user in users}
     for pool_member in pool:
         if pool_member.content_uri.split(":")[1] == "track":
-            tracks.append(PoolTrack(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
-                                    spotify_track_uri=pool_member.content_uri, duration_ms=pool_member.duration_ms))
+            users_map[pool_member.user_id].tracks.append(
+                PoolTrack(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
+                          spotify_track_uri=pool_member.content_uri, duration_ms=pool_member.duration_ms))
         else:
-            collections.append(PoolCollection(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
-                                              tracks=_create_collection_tracks(pool_member),
-                                              spotify_collection_uri=pool_member.content_uri))
-    return PoolFullContents(tracks=tracks, collections=collections)
+            users_map[pool_member.user_id].collections.append(
+                PoolCollection(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
+                               tracks=_create_collection_tracks(pool_member),
+                               spotify_collection_uri=pool_member.content_uri))
+    return PoolFullContents(users=list(users_map.values()))

--- a/server/src/api/pool/helpers.py
+++ b/server/src/api/pool/helpers.py
@@ -15,7 +15,8 @@ def _create_collection_tracks(collection: PoolMember) -> list[PoolTrack]:
             for track in collection.children]
 
 
-def create_pool_return_model(pool: list[PoolMember], users: list[User]) -> PoolFullContents:
+def create_pool_return_model(pool: list[PoolMember], users: list[User],
+                             share_code: str | None = None) -> PoolFullContents:
     _logger.debug(f"Creating pool return model from {len(pool)} members.")
     users_map = {user.spotify_id: PoolUserContents(tracks=[],
                                                    collections=[],
@@ -31,4 +32,4 @@ def create_pool_return_model(pool: list[PoolMember], users: list[User]) -> PoolF
                 PoolCollection(name=pool_member.name, spotify_icon_uri=pool_member.image_url,
                                tracks=_create_collection_tracks(pool_member),
                                spotify_collection_uri=pool_member.content_uri))
-    return PoolFullContents(users=list(users_map.values()))
+    return PoolFullContents(users=list(users_map.values()), share_code=share_code)

--- a/server/src/api/pool/models.py
+++ b/server/src/api/pool/models.py
@@ -34,7 +34,3 @@ class PoolUserContents(BaseModel):
 class PoolFullContents(BaseModel):
     users: list[PoolUserContents]
     share_code: str | None = None
-
-
-class PoolJoiningData(BaseModel):
-    code: str

--- a/server/src/api/pool/models.py
+++ b/server/src/api/pool/models.py
@@ -33,7 +33,4 @@ class PoolUserContents(BaseModel):
 
 class PoolFullContents(BaseModel):
     users: list[PoolUserContents]
-
-
-class SharedPool(BaseModel):
-    code: str
+    share_code: str | None = None

--- a/server/src/api/pool/models.py
+++ b/server/src/api/pool/models.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+from api.common.models import UserModel
+
 
 class PoolContent(BaseModel):
     spotify_uri: str
@@ -23,6 +25,15 @@ class PoolCollection(BaseModel):
     tracks: list[PoolTrack]
 
 
-class Pool(BaseModel):
+class PoolUserContents(BaseModel):
     tracks: list[PoolTrack]
     collections: list[PoolCollection]
+    user: UserModel
+
+
+class PoolFullContents(BaseModel):
+    users: list[PoolUserContents]
+
+
+class SharedPool(BaseModel):
+    code: str

--- a/server/src/api/pool/models.py
+++ b/server/src/api/pool/models.py
@@ -34,3 +34,7 @@ class PoolUserContents(BaseModel):
 class PoolFullContents(BaseModel):
     users: list[PoolUserContents]
     share_code: str | None = None
+
+
+class PoolJoiningData(BaseModel):
+    code: str

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -40,7 +40,8 @@ async def add_content(to_add: PoolContent, user: validated_user, spotify_client:
     _logger.debug(f"POST /pool/content called with content {to_add} and token {user.session.user_token}")
     added_content = spotify_client.get_pool_content(user, to_add)
     whole_pool = database_connection.add_to_pool(added_content, user)
-    return create_pool_return_model(whole_pool)
+    pool_users = database_connection.get_pool_users(user)
+    return create_pool_return_model(whole_pool, pool_users)
 
 
 @router.delete("/content/{spotify_uri}")

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -60,6 +60,13 @@ async def skip_song(user: validated_user, pool_playback_service: PoolPlaybackSer
 
 
 @router.post("/share")
-async def share_pool(user: validated_user, database_connection: PoolDatabaseConnection) -> PoolFullContents:
-    _logger.debug(f"POST /pool/share called with token {user}")
-    return create_pool_return_model(*database_connection.share_pool(user))
+async def share_pool(user: validated_user, pool_database_connection: PoolDatabaseConnection) -> PoolFullContents:
+    _logger.debug(f"POST /pool/share called with token {user.session.user_token}")
+    return create_pool_return_model(*pool_database_connection.share_pool(user))
+
+
+@router.post("/join/{code}")
+async def join_pool(code: str, user: validated_user,
+                    pool_database_connection: PoolDatabaseConnection) -> PoolFullContents:
+    _logger.debug(f"POST /pool/join called with code {code} and token {user.session.user_token}")
+    return create_pool_return_model(*pool_database_connection.join_pool(user, code))

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -2,10 +2,10 @@ from logging import getLogger
 
 from fastapi import APIRouter
 
-from api.common.dependencies import validated_token, TokenHolder
+from api.common.dependencies import validated_user, TokenHolder
 from api.pool.dependencies import PoolSpotifyClient, PoolDatabaseConnection, PoolPlaybackService
 from api.pool.helpers import create_pool_return_model
-from api.pool.models import PoolCreationData, Pool, PoolContent, PoolTrack
+from api.pool.models import PoolCreationData, PoolFullContents, PoolContent, PoolTrack, SharedPool
 
 _logger = getLogger("main.api.pool.routes")
 
@@ -17,27 +17,27 @@ router = APIRouter(
 
 
 @router.post("/")
-async def create_pool(base_collection: PoolCreationData, token: validated_token,
+async def create_pool(base_collection: PoolCreationData, user: validated_user,
                       spotify_client: PoolSpotifyClient, database_connection: PoolDatabaseConnection,
-                      token_holder: TokenHolder, pool_playback_service: PoolPlaybackService) -> Pool:
-    _logger.debug(f"POST /pool called with collection {base_collection} and token {token}")
-    pool_content = spotify_client.get_pool_content(token, *base_collection.spotify_uris)
-    database_connection.create_pool(pool_content, token_holder.get_from_token(token))
-    pool_playback_service.start_playback(token)
+                      pool_playback_service: PoolPlaybackService) -> PoolFullContents:
+    _logger.debug(f"POST /pool called with collection {base_collection} and token {user.session.user_token}")
+    pool_content = spotify_client.get_pool_content(user, *base_collection.spotify_uris)
+    database_connection.create_pool(pool_content)
+    pool_playback_service.start_playback(user)
     return pool_content
 
 
 @router.get("/")
-async def get_pool(token: validated_token, database_connection: PoolDatabaseConnection,
-                   token_holder: TokenHolder) -> Pool:
+async def get_pool(token: validated_user, database_connection: PoolDatabaseConnection,
+                   token_holder: TokenHolder) -> PoolFullContents:
     _logger.debug(f"GET /pool called with token {token}")
     pool = database_connection.get_pool(token_holder.get_from_token(token))
     return create_pool_return_model(pool)
 
 
 @router.post("/content")
-async def add_content(to_add: PoolContent, token: validated_token, spotify_client: PoolSpotifyClient,
-                      database_connection: PoolDatabaseConnection, token_holder: TokenHolder) -> Pool:
+async def add_content(to_add: PoolContent, token: validated_user, spotify_client: PoolSpotifyClient,
+                      database_connection: PoolDatabaseConnection, token_holder: TokenHolder) -> PoolFullContents:
     _logger.debug(f"POST /pool/content called with content {to_add} and token {token}")
     added_content = spotify_client.get_pool_content(token, to_add)
     whole_pool = database_connection.add_to_pool(added_content, token_holder.get_from_token(token))
@@ -45,14 +45,20 @@ async def add_content(to_add: PoolContent, token: validated_token, spotify_clien
 
 
 @router.delete("/content/{spotify_uri}")
-async def delete_content(spotify_uri: str, token: validated_token, database_connection: PoolDatabaseConnection,
-                         token_holder: TokenHolder) -> Pool:
+async def delete_content(spotify_uri: str, token: validated_user, database_connection: PoolDatabaseConnection,
+                         token_holder: TokenHolder) -> PoolFullContents:
     _logger.debug(f"DELETE /pool/content/{{spotify_uri}} called with uri {spotify_uri} and token {token}")
     whole_pool = database_connection.delete_from_pool(spotify_uri, token_holder.get_from_token(token))
     return create_pool_return_model(whole_pool)
 
 
 @router.post("/playback/skip")
-async def skip_song(token: validated_token, pool_playback_service: PoolPlaybackService) -> PoolTrack:
+async def skip_song(token: validated_user, pool_playback_service: PoolPlaybackService) -> PoolTrack:
     _logger.debug(f"POST /pool/playback/skip called with token {token}")
     return pool_playback_service.skip_song(token)
+
+
+@router.post("/share")
+async def share_pool(token: validated_user) -> SharedPool:
+    _logger.debug(f"POST /pool/share called with token {token}")
+    pass

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from api.common.dependencies import validated_user, TokenHolder
 from api.pool.dependencies import PoolSpotifyClient, PoolDatabaseConnection, PoolPlaybackService
 from api.pool.helpers import create_pool_return_model
-from api.pool.models import PoolCreationData, PoolFullContents, PoolContent, PoolTrack, SharedPool
+from api.pool.models import PoolCreationData, PoolFullContents, PoolContent, PoolTrack
 
 _logger = getLogger("main.api.pool.routes")
 
@@ -60,6 +60,6 @@ async def skip_song(user: validated_user, pool_playback_service: PoolPlaybackSer
 
 
 @router.post("/share")
-async def share_pool(token: validated_user) -> SharedPool:
-    _logger.debug(f"POST /pool/share called with token {token}")
-    pass
+async def share_pool(user: validated_user, database_connection: PoolDatabaseConnection) -> PoolFullContents:
+    _logger.debug(f"POST /pool/share called with token {user}")
+    return create_pool_return_model(*database_connection.share_pool(user))

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -27,11 +27,10 @@ async def create_pool(base_collection: PoolCreationData, user: validated_user,
 
 
 @router.get("/")
-async def get_pool(token: validated_user, database_connection: PoolDatabaseConnection,
-                   token_holder: TokenHolder) -> PoolFullContents:
-    _logger.debug(f"GET /pool called with token {token}")
-    pool = database_connection.get_pool(token_holder.get_from_token(token))
-    return create_pool_return_model(pool)
+async def get_pool(user: validated_user, database_connection: PoolDatabaseConnection) -> PoolFullContents:
+    _logger.debug(f"GET /pool called with token {user}")
+    pool, users = database_connection.get_pool(user)
+    return create_pool_return_model(pool, users)
 
 
 @router.post("/content")
@@ -55,9 +54,9 @@ async def delete_content(spotify_uri: str, user: validated_user, database_connec
 
 
 @router.post("/playback/skip")
-async def skip_song(token: validated_user, pool_playback_service: PoolPlaybackService) -> PoolTrack:
-    _logger.debug(f"POST /pool/playback/skip called with token {token}")
-    return pool_playback_service.skip_song(token)
+async def skip_song(user: validated_user, pool_playback_service: PoolPlaybackService) -> PoolTrack:
+    _logger.debug(f"POST /pool/playback/skip called with token {user.session.user_token}")
+    return pool_playback_service.skip_song(user)
 
 
 @router.post("/share")

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -29,8 +29,8 @@ async def create_pool(base_collection: PoolCreationData, user: validated_user,
 @router.get("/")
 async def get_pool(user: validated_user, database_connection: PoolDatabaseConnection) -> PoolFullContents:
     _logger.debug(f"GET /pool called with token {user}")
-    pool, users = database_connection.get_pool(user)
-    return create_pool_return_model(pool, users)
+    pool, users, code = database_connection.get_pool(user)
+    return create_pool_return_model(pool, users, code)
 
 
 @router.post("/content")

--- a/server/src/api/pool/tasks.py
+++ b/server/src/api/pool/tasks.py
@@ -1,16 +1,18 @@
 import random
 from logging import getLogger
 
-from api.common.dependencies import SpotifyClient, RequestsClientRaw, TokenHolder
+from api.common.dependencies import SpotifyClient, RequestsClientRaw, TokenHolder, UserDatabaseConnection
 from api.pool.dependencies import PoolDatabaseConnection, PoolSpotifyClient, PoolPlaybackService
 from database.database_connection import ConnectionManager
 from database.entities import PlaybackSession, PoolMember
 
 _logger = getLogger("main.api.pool.tasks")
 
-_pool_db_connection = PoolDatabaseConnection(ConnectionManager())
+_connection_manager = ConnectionManager()
+_pool_db_connection = PoolDatabaseConnection(_connection_manager)
 _pool_spotify_client = PoolSpotifyClient(SpotifyClient(RequestsClientRaw()))
-_token_holder = TokenHolder()
+_user_db_connection = UserDatabaseConnection(_connection_manager)
+_token_holder = TokenHolder(_user_db_connection)
 _pool_playback_service = PoolPlaybackService(_pool_db_connection, _pool_spotify_client, _token_holder)
 
 

--- a/server/src/api/search/routes.py
+++ b/server/src/api/search/routes.py
@@ -18,39 +18,39 @@ router = APIRouter(
 
 
 @router.get("/")
-async def search(query: str, token: validated_user, spotify_client: SearchSpotifyClient) -> GeneralSearchResult:
-    _logger.debug(f"GET /search called with query '{query}' and token '{token}'.")
+async def search(query: str, user: validated_user, spotify_client: SearchSpotifyClient) -> GeneralSearchResult:
+    _logger.debug(f"GET /search called with query '{query}' and token '{user}'.")
     all_playable_types = [e.value for e in SpotifyPlayableType]
-    return spotify_client.get_general_search(query, token, all_playable_types)
+    return spotify_client.get_general_search(query, user, all_playable_types)
 
 
 @router.get("/tracks")
-async def search_tracks(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_tracks(user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                         limit: int = 20) -> TrackSearchResult:
     _logger.debug(f"GET /search/tracks called with query '{query}', "
-                  f"offset {offset}, limit {limit} and token '{token}'.")
-    return spotify_client.get_track_search(query, token, offset, limit)
+                  f"offset {offset}, limit {limit} and token '{user}'.")
+    return spotify_client.get_track_search(query, user, offset, limit)
 
 
 @router.get("/albums")
-async def search_albums(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_albums(user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                         limit: int = 20) -> AlbumSearchResult:
     _logger.debug(f"GET /search/albums called with query '{query}', "
-                  f"offset {offset}, limit {limit} and token '{token}'.")
-    return spotify_client.get_album_search(query, token, offset, limit)
+                  f"offset {offset}, limit {limit} and token '{user}'.")
+    return spotify_client.get_album_search(query, user, offset, limit)
 
 
 @router.get("/artists")
-async def search_artists(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_artists(user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                          limit: int = 20) -> ArtistSearchResult:
     _logger.debug(f"GET /search/artists called with query '{query}', "
-                  f"offset {offset}, limit {limit} and token '{token}'.")
-    return spotify_client.get_artist_search(query, token, offset, limit)
+                  f"offset {offset}, limit {limit} and token '{user}'.")
+    return spotify_client.get_artist_search(query, user, offset, limit)
 
 
 @router.get("/playlists")
-async def search_playlists(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_playlists(user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                            limit: int = 20) -> PlaylistSearchResult:
     _logger.debug(f"GET /search/playlists called with query '{query}', "
-                  f"offset {offset}, limit {limit} and token '{token}'.")
-    return spotify_client.get_playlist_search(query, token, offset, limit)
+                  f"offset {offset}, limit {limit} and token '{user}'.")
+    return spotify_client.get_playlist_search(query, user, offset, limit)

--- a/server/src/api/search/routes.py
+++ b/server/src/api/search/routes.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from fastapi import APIRouter
 
-from api.common.dependencies import validated_token
+from api.common.dependencies import validated_user
 from api.search.dependencies import SearchSpotifyClient
 from api.search.models import GeneralSearchResult, SpotifyPlayableType, TrackSearchResult, AlbumSearchResult, \
     ArtistSearchResult, PlaylistSearchResult
@@ -18,14 +18,14 @@ router = APIRouter(
 
 
 @router.get("/")
-async def search(query: str, token: validated_token, spotify_client: SearchSpotifyClient) -> GeneralSearchResult:
+async def search(query: str, token: validated_user, spotify_client: SearchSpotifyClient) -> GeneralSearchResult:
     _logger.debug(f"GET /search called with query '{query}' and token '{token}'.")
     all_playable_types = [e.value for e in SpotifyPlayableType]
     return spotify_client.get_general_search(query, token, all_playable_types)
 
 
 @router.get("/tracks")
-async def search_tracks(token: validated_token, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_tracks(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                         limit: int = 20) -> TrackSearchResult:
     _logger.debug(f"GET /search/tracks called with query '{query}', "
                   f"offset {offset}, limit {limit} and token '{token}'.")
@@ -33,7 +33,7 @@ async def search_tracks(token: validated_token, spotify_client: SearchSpotifyCli
 
 
 @router.get("/albums")
-async def search_albums(token: validated_token, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_albums(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                         limit: int = 20) -> AlbumSearchResult:
     _logger.debug(f"GET /search/albums called with query '{query}', "
                   f"offset {offset}, limit {limit} and token '{token}'.")
@@ -41,7 +41,7 @@ async def search_albums(token: validated_token, spotify_client: SearchSpotifyCli
 
 
 @router.get("/artists")
-async def search_artists(token: validated_token, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_artists(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                          limit: int = 20) -> ArtistSearchResult:
     _logger.debug(f"GET /search/artists called with query '{query}', "
                   f"offset {offset}, limit {limit} and token '{token}'.")
@@ -49,7 +49,7 @@ async def search_artists(token: validated_token, spotify_client: SearchSpotifyCl
 
 
 @router.get("/playlists")
-async def search_playlists(token: validated_token, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
+async def search_playlists(token: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0,
                            limit: int = 20) -> PlaylistSearchResult:
     _logger.debug(f"GET /search/playlists called with query '{query}', "
                   f"offset {offset}, limit {limit} and token '{token}'.")

--- a/server/src/database/entities.py
+++ b/server/src/database/entities.py
@@ -60,12 +60,15 @@ class Pool(EntityBase):
     owner_user_id: Mapped[int] = mapped_column(ForeignKey("User.spotify_id"), nullable=False)
 
     joined_users: Mapped[list["PoolJoinedUser"]] = relationship(lazy="joined", back_populates="pool")
+    share_data: Mapped["PoolShareData"] = relationship(lazy="joined", back_populates="pool")
 
 
-class PoolJoinCode(EntityBase):
+class PoolShareData(EntityBase):
     pool_id: Mapped[int] = mapped_column(ForeignKey("Pool.id", onupdate="CASCADE", ondelete="CASCADE"),
                                          primary_key=True)
     code: Mapped[str] = mapped_column(String(8), nullable=False)
+
+    pool: Mapped["Pool"] = relationship(lazy="joined", back_populates="share_data")
 
 
 class PoolJoinedUser(EntityBase):

--- a/server/src/database/entities.py
+++ b/server/src/database/entities.py
@@ -19,7 +19,9 @@ class User(EntityBase):
     spotify_id: Mapped[str] = mapped_column(String(64), primary_key=True)
     spotify_username: Mapped[str] = mapped_column(String(64))
     spotify_avatar_url: Mapped[str] = mapped_column(String(256), nullable=True)
+
     session: Mapped["UserSession"] = relationship(lazy="joined", back_populates="user")
+    joined_pool: Mapped["PoolJoinedUser"] = relationship(lazy="joined", back_populates="user")
 
 
 class UserSession(EntityBase):
@@ -57,11 +59,21 @@ class Pool(EntityBase):
     name: Mapped[str] = mapped_column(String(32), nullable=True)  # Name null -> user transient pool
     owner_user_id: Mapped[int] = mapped_column(ForeignKey("User.spotify_id"), nullable=False)
 
+    joined_users: Mapped[list["PoolJoinedUser"]] = relationship(lazy="joined", back_populates="pool")
+
 
 class PoolJoinCode(EntityBase):
     pool_id: Mapped[int] = mapped_column(ForeignKey("Pool.id", onupdate="CASCADE", ondelete="CASCADE"),
                                          primary_key=True)
     code: Mapped[str] = mapped_column(String(8), nullable=False)
+
+
+class PoolJoinedUser(EntityBase):
+    user_id: Mapped[str] = mapped_column(ForeignKey("User.spotify_id"), primary_key=True)
+    pool_id: Mapped[int] = mapped_column(ForeignKey("Pool.id", onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+
+    pool: Mapped["Pool"] = relationship(lazy="joined", back_populates="joined_users")
+    user: Mapped["User"] = relationship(lazy="joined", back_populates="joined_pool")
 
 
 class PlaybackSession(EntityBase):

--- a/server/test/auth_features/auth_login_callback_features.py
+++ b/server/test/auth_features/auth_login_callback_features.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy import select
 
-from api.common.dependencies import validated_token_raw
+from api.common.dependencies import validated_user_raw
 from database.entities import LoginState, User
 
 
@@ -89,7 +89,7 @@ def requests_client_with_auth_mock(requests_client, default_token_return, defaul
 def auth_test(test_client, mock_token_holder):
 
     def auth_test_wrapper(token):
-        return validated_token_raw(token, mock_token_holder)
+        return validated_user_raw(token, mock_token_holder)
 
     return auth_test_wrapper
 
@@ -204,7 +204,7 @@ def should_save_token_on_success_and_auth_with_token_afterwards(auth_test, corre
     response = base_auth_callback_call()
     json_data = validate_response(response)
     actual_token = auth_test(json_data["access_token"])
-    assert actual_token == json_data["access_token"]
+    assert actual_token.session.user_token == json_data["access_token"]
 
 
 @pytest.mark.parametrize("code", [401, 403, 404, 500])

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from api.application import create_app
+from api.auth.dependencies import AuthDatabaseConnection
 from api.common.dependencies import RequestsClientRaw, TokenHolder, TokenHolderRaw, UserDatabaseConnection
 from api.common.models import ParsedTokenResponse
 from database.database_connection import ConnectionManager
@@ -73,8 +74,9 @@ def logged_in_user(logged_in_user_id) -> User:
 
 
 @pytest.fixture
-def valid_token_header(mock_token_holder, logged_in_user, valid_token_data):
-    mock_token_holder.log_in(valid_token_data, logged_in_user)
+def valid_token_header(db_connection, logged_in_user, valid_token_data):
+    auth_database_connection = AuthDatabaseConnection(db_connection)
+    auth_database_connection.update_logged_in_user(logged_in_user, valid_token_data)
     return {"token": valid_token_data.token}
 
 

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -7,9 +7,11 @@ import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from api.common.dependencies import RequestsClientRaw, TokenHolder, TokenHolderRaw
-from database.database_connection import ConnectionManager
 from api.application import create_app
+from api.common.dependencies import RequestsClientRaw, TokenHolder, TokenHolderRaw, UserDatabaseConnection
+from api.common.models import ParsedTokenResponse
+from database.database_connection import ConnectionManager
+from database.entities import User
 
 
 @pytest.fixture
@@ -52,17 +54,24 @@ def validate_response():
 
 
 @pytest.fixture
-def mock_token_holder(application):
-    token_holder = TokenHolder()
+def mock_token_holder(application, db_connection):
+    user_database_connection = UserDatabaseConnection(db_connection)
+    token_holder = TokenHolder(user_database_connection)
     application.dependency_overrides[TokenHolderRaw] = lambda: token_holder
     return token_holder
 
 
 @pytest.fixture
-def valid_token_header(mock_token_holder, logged_in_user_id):
-    token = "my test token"
-    mock_token_holder.add_token(token, Mock(spotify_id=logged_in_user_id))
-    return {"token": token}
+def valid_token_data():
+    return ParsedTokenResponse(token="my test token", refresh_token="my refresh token", expires_in=999999)
+
+
+@pytest.fixture
+def valid_token_header(mock_token_holder, logged_in_user_id, valid_token_data):
+    user = User(spotify_id=logged_in_user_id, spotify_username=logged_in_user_id,
+                spotify_avatar_url=f"user.icon.example")
+    mock_token_holder.log_in(valid_token_data, user)
+    return {"token": valid_token_data.token}
 
 
 @pytest.fixture
@@ -113,12 +122,12 @@ def create_mock_artist_search_result(faker):
             "type": "artist",
             "uri": f"spotify:artist:{artist_id}"
         }
+
     return wrapper
 
 
 @pytest.fixture
 def create_mock_album_search_result(faker):
-
     def wrapper(artist: dict, tracks: list[dict] | None = None):
         album_name = faker.text(max_nb_chars=25)[:-1]
         album_id = faker.uuid4()
@@ -170,6 +179,7 @@ def create_mock_album_search_result(faker):
                 "items": tracks
             }
         return album_data
+
     return wrapper
 
 
@@ -283,4 +293,5 @@ def get_query_parameter():
         match = re.match(fr".*[&?]{parameter_name}=([^{restricted_characters}]+)(?:$|&.*)", query_string)
         assert match, f"Could not find query parameter {parameter_name} in query '{query_string}'"
         return match.group(1)
+
     return wrapper

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -62,15 +62,19 @@ def mock_token_holder(application, db_connection):
 
 
 @pytest.fixture
-def valid_token_data():
+def valid_token_data() -> ParsedTokenResponse:
     return ParsedTokenResponse(token="my test token", refresh_token="my refresh token", expires_in=999999)
 
 
 @pytest.fixture
-def valid_token_header(mock_token_holder, logged_in_user_id, valid_token_data):
-    user = User(spotify_id=logged_in_user_id, spotify_username=logged_in_user_id,
+def logged_in_user(logged_in_user_id) -> User:
+    return User(spotify_id=logged_in_user_id, spotify_username=logged_in_user_id,
                 spotify_avatar_url=f"user.icon.example")
-    mock_token_holder.log_in(valid_token_data, user)
+
+
+@pytest.fixture
+def valid_token_header(mock_token_holder, logged_in_user, valid_token_data):
+    mock_token_holder.log_in(valid_token_data, logged_in_user)
     return {"token": valid_token_data.token}
 
 

--- a/server/test/pool_features/add_content_features.py
+++ b/server/test/pool_features/add_content_features.py
@@ -16,7 +16,7 @@ def should_create_a_pool_member_for_user_even_if_user_pool_is_empty(create_mock_
     response = test_client.post("/pool/content", json=pool_content_data, headers=valid_token_header)
 
     pool_response = validate_response(response)
-    assert len(pool_response["tracks"]) == 1
+    assert len(pool_response["users"][0]["tracks"]) == 1
 
 
 def should_save_the_pool_member_to_database_even_if_user_pool_is_empty(create_mock_track_search_result, requests_client,
@@ -66,7 +66,8 @@ def should_correctly_construct_pool_after_collection_addition(requests_client,
             and_(PoolMember.user_id == logged_in_user_id, PoolMember.parent_id == None))).unique().all()
     assert len(actual_pool_content) == len(existing_pool) + 1
     pool_response = validate_response(response)
-    assert len(pool_response["collections"][0]["tracks"]) == len(playlist["tracks"]["items"])
+    user_pool = pool_response["users"][0]
+    assert len(user_pool["collections"][0]["tracks"]) == len(playlist["tracks"]["items"])
 
 
 def should_use_collection_icon_as_track_icon_on_collection_addition(create_mock_track_search_result, requests_client,
@@ -83,5 +84,6 @@ def should_use_collection_icon_as_track_icon_on_collection_addition(create_mock_
     response = test_client.post("/pool/content", json=pool_content_data, headers=valid_token_header)
 
     pool_response = validate_response(response)
-    for track in pool_response["collections"][0]["tracks"]:
+    user_pool = pool_response["users"][0]
+    for track in user_pool["collections"][0]["tracks"]:
         assert track["spotify_icon_uri"] == album["images"][0]["url"]

--- a/server/test/pool_features/conftest.py
+++ b/server/test/pool_features/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import select
 from starlette.testclient import TestClient
 
+from api.auth.dependencies import AuthDatabaseConnection
 from api.common.models import ParsedTokenResponse
 from api.pool.models import PoolCreationData, PoolContent
 from database.database_connection import ConnectionManager
@@ -153,11 +154,12 @@ def existing_playback(db_connection: ConnectionManager, create_mock_track_search
 
 
 @pytest.fixture
-def another_logged_in_user_header(faker, mock_token_holder):
+def another_logged_in_user_header(faker, db_connection):
+    auth_database_connection = AuthDatabaseConnection(db_connection)
     user_id = faker.uuid4()
     user = User(spotify_id=user_id, spotify_username=user_id, spotify_avatar_url=f"user.icon.example")
     token_data = ParsedTokenResponse(token="my test token 2", refresh_token="my refresh token 2", expires_in=999999)
-    mock_token_holder.log_in(token_data, user)
+    auth_database_connection.update_logged_in_user(user, token_data)
     return {"token": token_data.token}
 
 

--- a/server/test/pool_features/conftest.py
+++ b/server/test/pool_features/conftest.py
@@ -4,8 +4,10 @@ from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import select
+from starlette.testclient import TestClient
 
 from api.pool.models import PoolCreationData, PoolContent
+from database.database_connection import ConnectionManager
 from database.entities import PoolMember
 
 
@@ -127,3 +129,23 @@ def create_mock_playlist_fetch_result(create_mock_track_search_result, faker):
         return playlist_data, *further_fetches
 
     return wrapper
+
+
+@pytest.fixture
+def fixed_track_length_ms(minutes: int = 3, seconds: int = 30):
+    return (minutes * 60 + seconds) * 1000
+
+
+@pytest.fixture
+def existing_playback(db_connection: ConnectionManager, create_mock_track_search_result,
+                      build_success_response, requests_client, create_pool_creation_data_json,
+                      test_client: TestClient, valid_token_header, fixed_track_length_ms):
+    tracks = [create_mock_track_search_result() for _ in range(15)]
+    for track in tracks:
+        track["duration_ms"] = fixed_track_length_ms
+    responses = [build_success_response(track) for track in tracks]
+    requests_client.get = Mock(side_effect=responses)
+    track_uris = [track["uri"] for track in tracks]
+    data_json = create_pool_creation_data_json(*track_uris)
+    test_client.post("/pool", json=data_json, headers=valid_token_header)
+    return tracks

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -233,6 +233,7 @@ def should_be_able_to_post_multiple_pool_members_on_creation(test_client: TestCl
         assert len(actual_results) == len(tracks) + 3
 
 
+@pytest.mark.slow
 def should_fetch_multiple_times_if_playlist_is_too_long_to_fetch_in_one_go(test_client: TestClient, valid_token_header,
                                                                            db_connection, requests_client,
                                                                            create_mock_playlist_fetch_result,

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -9,6 +9,7 @@ from database.database_connection import ConnectionManager
 from database.entities import PoolMember
 
 
+@pytest.mark.wip
 def should_create_pool_of_one_song_when_post_pool_called_with_single_song_id(test_client: TestClient,
                                                                              valid_token_header,
                                                                              validate_response,
@@ -21,7 +22,7 @@ def should_create_pool_of_one_song_when_post_pool_called_with_single_song_id(tes
     requests_client.get = Mock(return_value=build_success_response(my_track))
     response = test_client.post("/pool", json=data_json, headers=valid_token_header)
     pool_response = validate_response(response)
-    assert pool_response["tracks"][0]["name"] == my_track["name"]
+    assert pool_response["users"][0]["tracks"][0]["name"] == my_track["name"]
 
 
 def should_save_pool_in_database_with_user_id_when_created(test_client: TestClient, db_connection: ConnectionManager,

--- a/server/test/pool_features/delete_content_features.py
+++ b/server/test/pool_features/delete_content_features.py
@@ -10,7 +10,7 @@ def should_delete_track_and_return_remaining_pool_if_given_track_id(existing_poo
     response = test_client.delete(f"/pool/content/{existing_pool[0].content_uri}", headers=valid_token_header)
 
     pool_response = validate_response(response)
-    assert len(pool_response["tracks"]) == len(existing_pool) - 1
+    assert len(pool_response["users"][0]["tracks"]) == len(existing_pool) - 1
 
 
 def should_not_have_track_in_database_after_deletion(existing_pool: list[PoolMember], valid_token_header, test_client,
@@ -34,7 +34,8 @@ def should_be_able_to_delete_separate_child_from_collection(create_mock_track_se
 
     response = test_client.delete(f"/pool/content/{expected_tracks[5]["uri"]}", headers=valid_token_header)
     pool_response = validate_response(response)
-    assert len(pool_response["collections"][0]["tracks"]) == len(expected_tracks) - 1
+    user_pool = pool_response["users"][0]
+    assert len(user_pool["collections"][0]["tracks"]) == len(expected_tracks) - 1
     with db_connection.session() as session:
         all_tracks = session.scalars(select(PoolMember).where(
             and_(PoolMember.parent_id != None, PoolMember.user_id == logged_in_user_id))).unique().all()
@@ -55,7 +56,8 @@ def should_delete_all_children_on_parent_deletion(create_mock_track_search_resul
     response = test_client.delete(f"/pool/content/{playlist["uri"]}", headers=valid_token_header)
 
     pool_response = validate_response(response)
-    assert len(pool_response["collections"]) == 0
+    user_pool = pool_response["users"][0]
+    assert len(user_pool["collections"]) == 0
     with db_connection.session() as session:
         all_tracks = session.scalars(select(PoolMember).where(
             and_(PoolMember.parent_id != None, PoolMember.user_id == logged_in_user_id))).unique().all()

--- a/server/test/pool_features/get_pool_features.py
+++ b/server/test/pool_features/get_pool_features.py
@@ -7,7 +7,7 @@ def should_get_all_existing_tracks(existing_pool, test_client, valid_token_heade
     response = test_client.get("/pool", headers=valid_token_header)
 
     pool_response = validate_response(response)
-    assert len(pool_response["tracks"]) == len(existing_pool)
+    assert len(pool_response["users"][0]["tracks"]) == len(existing_pool)
 
 
 def should_return_mix_of_tracks_and_collections_correctly(test_client, valid_token_header, validate_response,
@@ -29,5 +29,6 @@ def should_return_mix_of_tracks_and_collections_correctly(test_client, valid_tok
     response = test_client.get("/pool", headers=valid_token_header)
 
     pool_response = validate_response(response)
-    assert len(pool_response["tracks"]) == len(existing_pool)
-    assert len(pool_response["collections"]) == 3
+    user_pool = pool_response["users"][0]
+    assert len(user_pool["tracks"]) == len(existing_pool)
+    assert len(user_pool["collections"]) == 3

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -80,6 +80,7 @@ def should_start_pool_playback_from_playlist_fetch_data_correctly(create_mock_pl
     assert call_uri in [track["track"]["uri"] for track in playlist["tracks"]["items"]]
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("repeat", range(15))
 def should_not_start_pool_playback_from_collection_uri_when_posting_collection(create_mock_track_search_result,
                                                                                create_mock_playlist_fetch_result,

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -6,6 +6,7 @@ import pytest
 from sqlalchemy import select
 from starlette.testclient import TestClient
 
+from api.auth.dependencies import AuthDatabaseConnection
 from api.common.dependencies import RequestsClient, SpotifyClientRaw, TokenHolder
 from api.pool.dependencies import PoolDatabaseConnectionRaw, PoolSpotifyClientRaw, PoolPlaybackServiceRaw
 from api.pool.tasks import queue_next_songs
@@ -202,7 +203,7 @@ def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_ser
 
     monkeypatch.setattr(datetime, "datetime", MockDateTime)
     queue_next_songs(playback_service)
-    mock_token_holder.log_in(valid_token_data, logged_in_user)
+    AuthDatabaseConnection(db_connection).update_logged_in_user(logged_in_user, valid_token_data)
 
     tracks = [create_mock_track_search_result() for _ in range(1)]
     responses = [build_success_response(track) for track in tracks]

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -14,26 +14,6 @@ from database.entities import PlaybackSession
 
 
 @pytest.fixture
-def fixed_track_length_ms(minutes: int = 3, seconds: int = 30):
-    return (minutes * 60 + seconds) * 1000
-
-
-@pytest.fixture
-def existing_playback(db_connection: ConnectionManager, create_mock_track_search_result,
-                      build_success_response, requests_client, create_pool_creation_data_json,
-                      test_client: TestClient, valid_token_header, fixed_track_length_ms):
-    tracks = [create_mock_track_search_result() for _ in range(15)]
-    for track in tracks:
-        track["duration_ms"] = fixed_track_length_ms
-    responses = [build_success_response(track) for track in tracks]
-    requests_client.get = Mock(side_effect=responses)
-    track_uris = [track["uri"] for track in tracks]
-    data_json = create_pool_creation_data_json(*track_uris)
-    test_client.post("/pool", json=data_json, headers=valid_token_header)
-    return tracks
-
-
-@pytest.fixture
 def pool_db_connection(db_connection: ConnectionManager):
     return PoolDatabaseConnectionRaw(db_connection)
 

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -220,7 +220,7 @@ def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_ser
 
     monkeypatch.setattr(datetime, "datetime", MockDateTime)
     queue_next_songs(playback_service)
-    mock_token_holder.add_token(valid_token_header["token"], Mock(spotify_id=logged_in_user_id))
+    mock_token_holder.log_in(valid_token_header["token"], Mock(spotify_id=logged_in_user_id))
 
     tracks = [create_mock_track_search_result() for _ in range(1)]
     responses = [build_success_response(track) for track in tracks]

--- a/server/test/pool_features/pool_websocket_features.py
+++ b/server/test/pool_features/pool_websocket_features.py
@@ -1,0 +1,39 @@
+import random
+from unittest.mock import Mock
+
+from api.pool.models import PoolContent
+
+
+def should_get_update_when_pool_contents_added(test_client, valid_token_header, shared_pool_code,
+                                               another_logged_in_user_header, build_success_response,
+                                               create_mock_playlist_fetch_result, requests_client, logged_in_user_id):
+    test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+    with test_client.websocket_connect("/pool/register_listener", headers=another_logged_in_user_header) as websocket:
+        playlist = create_mock_playlist_fetch_result(15)
+        requests_client.get = Mock(return_value=build_success_response(playlist))
+        pool_content_data = PoolContent(spotify_uri=playlist["uri"]).model_dump()
+        test_client.post("/pool/content", json=pool_content_data, headers=valid_token_header)
+        data = websocket.receive_json()
+        for user_data in data["users"]:
+            if user_data["user"]["spotify_id"] == logged_in_user_id:
+                assert len(user_data["collections"]) == 1
+
+
+def should_get_update_when_pool_contents_deleted(test_client, valid_token_header, shared_pool_code,
+                                                 another_logged_in_user_header, logged_in_user_id, existing_playback):
+    test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+    with test_client.websocket_connect("/pool/register_listener", headers=another_logged_in_user_header) as websocket:
+        deleted_song = random.choice(existing_playback)
+        test_client.delete(f"/pool/content/{deleted_song["uri"]}", headers=valid_token_header)
+        data = websocket.receive_json()
+        for user_data in data["users"]:
+            if user_data["user"]["spotify_id"] == logged_in_user_id:
+                assert len(user_data["tracks"]) == len(existing_playback) - 1
+
+
+def should_get_update_when_user_joins_pool(test_client, valid_token_header, shared_pool_code,
+                                           another_logged_in_user_header, logged_in_user_id, existing_playback):
+    with test_client.websocket_connect("/pool/register_listener", headers=valid_token_header) as websocket:
+        test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+        data = websocket.receive_json()
+        assert len(data["users"]) == 2

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -2,5 +2,21 @@ def should_return_pool_code_from_share_route(existing_playback, test_client, val
     response = test_client.post("/pool/share", headers=valid_token_header)
 
     result = validate_response(response)
+    assert result["share_code"] is not None
     assert type(result["share_code"]) == str
+
+
+def should_have_only_uppercase_letters_and_digits_in_share_code(existing_playback, test_client, validate_response,
+                                                                valid_token_header):
+    response = test_client.post("/pool/share", headers=valid_token_header)
+
+    result = validate_response(response)
+    for char in result["share_code"]:
+        assert char.isupper() or char.isdigit()
+
+
+def should_have_eight_characters_in_share_code(existing_playback, test_client, validate_response, valid_token_header):
+    response = test_client.post("/pool/share", headers=valid_token_header)
+
+    result = validate_response(response)
     assert len(result["share_code"]) == 8

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -1,6 +1,6 @@
-def should_return_pool_code_from_share_route(test_client, validate_response):
-    response = test_client.post("/pool/share")
+def should_return_pool_code_from_share_route(existing_playback, test_client, validate_response, valid_token_header):
+    response = test_client.post("/pool/share", headers=valid_token_header)
 
     result = validate_response(response)
-    assert type(result["code"]) == str
-    assert len(result["code"]) == 8
+    assert type(result["share_code"]) == str
+    assert len(result["share_code"]) == 8

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -2,26 +2,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from api.common.models import ParsedTokenResponse
 from api.pool.models import PoolContent
-from database.entities import User
 
-
-@pytest.fixture
-def another_logged_in_user_header(faker, mock_token_holder):
-    user_id = faker.uuid4()
-    user = User(spotify_id=user_id, spotify_username=user_id, spotify_avatar_url=f"user.icon.example")
-    token_data = ParsedTokenResponse(token="my test token 2", refresh_token="my refresh token 2", expires_in=999999)
-    mock_token_holder.log_in(token_data, user)
-    return {"token": token_data.token}
-
-
-@pytest.fixture
-def shared_pool_code(existing_playback, test_client, valid_token_header, validate_response) -> str:
-    response = test_client.post("/pool/share", headers=valid_token_header)
-
-    result = validate_response(response)
-    return result["share_code"]
 
 
 def should_return_pool_code_from_share_route(existing_playback, test_client, validate_response, valid_token_header):

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -1,3 +1,29 @@
+from unittest.mock import Mock
+
+import pytest
+
+from api.common.models import ParsedTokenResponse
+from api.pool.models import PoolContent
+from database.entities import User
+
+
+@pytest.fixture
+def another_logged_in_user_header(faker, mock_token_holder):
+    user_id = faker.uuid4()
+    user = User(spotify_id=user_id, spotify_username=user_id, spotify_avatar_url=f"user.icon.example")
+    token_data = ParsedTokenResponse(token="my test token 2", refresh_token="my refresh token 2", expires_in=999999)
+    mock_token_holder.log_in(token_data, user)
+    return {"token": token_data.token}
+
+
+@pytest.fixture
+def shared_pool_code(existing_playback, test_client, valid_token_header, validate_response) -> str:
+    response = test_client.post("/pool/share", headers=valid_token_header)
+
+    result = validate_response(response)
+    return result["share_code"]
+
+
 def should_return_pool_code_from_share_route(existing_playback, test_client, validate_response, valid_token_header):
     response = test_client.post("/pool/share", headers=valid_token_header)
 
@@ -20,3 +46,41 @@ def should_have_eight_characters_in_share_code(existing_playback, test_client, v
 
     result = validate_response(response)
     assert len(result["share_code"]) == 8
+
+
+def should_be_able_to_join_shared_pool_with_code(shared_pool_code, test_client, another_logged_in_user_header,
+                                                 validate_response):
+    response = test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+
+    result = validate_response(response)
+    assert len(result["users"]) == 2
+    assert result["share_code"] == shared_pool_code
+
+
+def should_see_pool_existing_songs_when_joining_shared_pool(shared_pool_code, test_client,
+                                                            another_logged_in_user_header, validate_response,
+                                                            logged_in_user_id, existing_pool):
+    response = test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+
+    result = validate_response(response)
+    for user_content in result["users"]:
+        if user_content["user"]["spotify_id"] == logged_in_user_id:
+            assert len(user_content["tracks"]) == len(existing_pool)
+
+
+def should_show_added_songs_to_pool_main_user(shared_pool_code, test_client, another_logged_in_user_header,
+                                              validate_response, valid_token_header, existing_pool, logged_in_user_id,
+                                              create_mock_playlist_fetch_result, requests_client,
+                                              build_success_response):
+    test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
+    playlist = create_mock_playlist_fetch_result(35)
+    requests_client.get = Mock(return_value=build_success_response(playlist))
+    pool_content_data = PoolContent(spotify_uri=playlist["uri"]).model_dump()
+    test_client.post("/pool/content", json=pool_content_data, headers=another_logged_in_user_header)
+
+    response = test_client.get("/pool", headers=valid_token_header)
+
+    result = validate_response(response)
+    for user_content in result["users"]:
+        if user_content["user"]["spotify_id"] != logged_in_user_id:
+            assert len(user_content["collections"][0]["tracks"]) == 35

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -1,0 +1,6 @@
+def should_return_pool_code_from_share_route(test_client, validate_response):
+    response = test_client.post("/pool/share")
+
+    result = validate_response(response)
+    assert type(result["code"]) == str
+    assert len(result["code"]) == 8

--- a/server/test_requirements.txt
+++ b/server/test_requirements.txt
@@ -11,3 +11,4 @@ pytest-asyncio==0.23.4
 requests==2.31.0
 APScheduler==3.10.4
 Faker==22.6.0
+websockets==12.0


### PR DESCRIPTION
Major changes:

- Output model for pools changed
  - Now consists of a list of UserPool models. These are the same model as the old pool model, with added user data
  - Has share_code property in the root. Null if pool is not shared.
- Big database changes. Partly to facilitate this update, partly to future-proof the design
  - Login/auth handling is now done in database, instead of local state
    - Added the UserSession table to track this data
  - PoolMember now has the associated tables Pool (aggregate root), PoolShareData and PoolJoinedUser
 
 Additions:

- Routes for sharing and joining a pool
- Websocket for listening to pool updates

Everything tested, tests updated to follow new changes
