### PR TITLE
195 Create a new pool corrupts data in backend

### DIFF
--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -325,7 +325,7 @@ class PoolDatabaseConnectionRaw:
         with self._database_connection.session() as session:
             existing_playback = session.scalar(
                 select(PlaybackSession).where(PlaybackSession.user_id == user.spotify_id))
-            if existing_playback is not None and existing_playback.current_track is not None:
+            if existing_playback is not None and existing_playback.current_track_uri is not None:
                 _update_user_playback(existing_playback, playing_track, override_timestamp)
             else:
                 _crete_user_playback(session, user, playing_track)
@@ -444,7 +444,8 @@ class PoolPlaybackServiceRaw:
 
     def start_playback(self, user: User) -> PoolTrack:
         all_tracks = self._database_connection.get_playable_tracks(user)
-        next_track = random.choice(all_tracks)
+        users = self._database_connection.get_pool_users(user)
+        next_track = self._next_song_provider.select_next_song(all_tracks, users)
         self._spotify_client.start_playback(user, next_track.content_uri)
         self._database_connection.save_playback_status(user, next_track)
         return map_pool_member_entity_to_model(next_track)

--- a/server/src/database/entities.py
+++ b/server/src/database/entities.py
@@ -69,8 +69,8 @@ class PoolMemberRandomizationParameters(EntityBase):
 
 class Pool(EntityBase):
     id: Mapped[int] = mapped_column(Integer(), primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(32), nullable=True)  # Name null -> user transient pool
-    owner_user_id: Mapped[int] = mapped_column(ForeignKey("User.spotify_id"), nullable=False)
+    name: Mapped[str | None] = mapped_column(String(32), nullable=True)  # Name null -> user transient pool
+    owner_user_id: Mapped[str] = mapped_column(ForeignKey("User.spotify_id"), nullable=False)
 
     joined_users: Mapped[list["PoolJoinedUser"]] = relationship(lazy="joined", back_populates="pool")
     share_data: Mapped["PoolShareData"] = relationship(lazy="joined", back_populates="pool")


### PR DESCRIPTION
FK relationship was marking a property as null and causing core to think we are creating user's first pool. Changed to read a property that is not a relationship. Fixed small typing errors
Fixed playback starting not using the new randomization algorithm

No new test for this as SQLite doesn't respect FK functionality and thus this cannot be reproduced in our test suite as it stands