### PR TITLE
200 rename authorization header to adhere to industry standards

### DIFF
--- a/client/components/buttons/iconButtons/addToPoolButton.tsx
+++ b/client/components/buttons/iconButtons/addToPoolButton.tsx
@@ -28,7 +28,7 @@ export default function AddToPoolButton({
 
         axios
             .post(`${backend_uri}/pool/content`, requestData, {
-                headers: { token },
+                headers: { Authorization: token },
             })
             .then(function (response) {
                 updatePool(response.data)

--- a/client/components/buttons/iconButtons/deleteButton.tsx
+++ b/client/components/buttons/iconButtons/deleteButton.tsx
@@ -21,7 +21,7 @@ export default function DeleteButton({ poolItem, token, updatePool }: Props) {
                 .delete(
                     `${backend_uri}/pool/content/${(poolItem as PoolCollection).spotify_collection_uri}`,
                     {
-                        headers: { token },
+                        headers: { Authorization: token },
                     },
                 )
                 .then(function (response) {
@@ -35,7 +35,7 @@ export default function DeleteButton({ poolItem, token, updatePool }: Props) {
                 .delete(
                     `${backend_uri}/pool/content/${(poolItem as PoolTrack).spotify_track_uri}`,
                     {
-                        headers: { token },
+                        headers: { Authorization: token },
                     },
                 )
                 .then(function (response) {

--- a/client/components/buttons/iconButtons/showMoreIconButton.tsx
+++ b/client/components/buttons/iconButtons/showMoreIconButton.tsx
@@ -43,7 +43,7 @@ export default function ShowMoreIconButton({
 
         axios
             .post(`${backend_uri}/pool`, requestData, {
-                headers: { token },
+                headers: { Authorization: token },
             })
             .then(function (response) {
                 updatePool(response.data)

--- a/client/components/buttons/skipButton.tsx
+++ b/client/components/buttons/skipButton.tsx
@@ -6,7 +6,7 @@ function SkipButton(props: { disabled?: boolean; token: string }) {
     const backend_uri = process.env.NEXT_PUBLIC_BACKEND_URI
     const skip = () => {
         const headers = {
-            token: props.token,
+            Authorization: props.token,
         }
         axios
             .post(

--- a/client/components/layout/poolManager.tsx
+++ b/client/components/layout/poolManager.tsx
@@ -21,7 +21,7 @@ export default function ManagePool(props: {
                 `${backend_uri}/pool/share`,
                 {},
                 {
-                    headers: { token },
+                    headers: { Authorization: token },
                 },
             )
             .then(function (response) {

--- a/client/components/layout/search.tsx
+++ b/client/components/layout/search.tsx
@@ -42,7 +42,7 @@ export default function Search({
         axios
             .get(`${backend_uri}/search`, {
                 params: { query },
-                headers: { token },
+                headers: { Authorization: token },
             })
             .then(function (response) {
                 if (!expanded) {
@@ -61,7 +61,7 @@ export default function Search({
                 `${backend_uri}/pool/join/${idQuery}`,
                 {},
                 {
-                    headers: { token },
+                    headers: { Authorization: token },
                 },
             )
             .then(function (response) {

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -125,8 +125,10 @@ class TokenHolderRaw:
 TokenHolder = Annotated[TokenHolderRaw, Depends()]
 
 
-def validated_user_raw(token: Annotated[str, Header()], token_holder: TokenHolder) -> User:
-    return _get_user_from_token(token, token_holder)
+# Authorization is read case-sensitively from headers and needs to be capitalized
+# noinspection PyPep8Naming
+def validated_user_raw(Authorization: Annotated[str, Header()], token_holder: TokenHolder) -> User:
+    return _get_user_from_token(Authorization, token_holder)
 
 
 def _get_user_from_token(token, token_holder):
@@ -138,8 +140,10 @@ def _get_user_from_token(token, token_holder):
 validated_user = Annotated[User, Depends(validated_user_raw)]
 
 
-def validated_user_from_query_parameters_raw(token: str, token_holder: TokenHolder) -> User:
-    return _get_user_from_token(token, token_holder)
+# Authorization is read case-sensitively from headers and needs to be capitalized
+# noinspection PyPep8Naming
+def validated_user_from_query_parameters_raw(Authorization: str, token_holder: TokenHolder) -> User:
+    return _get_user_from_token(Authorization, token_holder)
 
 
 validated_user_from_query_parameters = Annotated[User, Depends(validated_user_from_query_parameters_raw)]

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -101,7 +101,7 @@ def log_user_in(auth_database_connection) -> Callable[[User, ParsedTokenResponse
 @pytest.fixture
 def create_header_from_token_response() -> Callable[[ParsedTokenResponse], dict[str, str]]:
     def wrapper(token_response: ParsedTokenResponse) -> dict[str, str]:
-        return {"token": token_response.token}
+        return {"Authorization": token_response.token}
 
     return wrapper
 

--- a/server/test/pool_features/conftest.py
+++ b/server/test/pool_features/conftest.py
@@ -161,7 +161,7 @@ def existing_playback(db_connection: ConnectionManager, create_mock_track_search
 
 @pytest.fixture
 def another_logged_in_user_header(another_logged_in_user_token):
-    return {"token": another_logged_in_user_token}
+    return {"Authorization": another_logged_in_user_token}
 
 
 @pytest.fixture

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -63,7 +63,7 @@ def should_be_able_to_create_pool_from_album(test_client: TestClient, valid_toke
     result = test_client.post("/pool", json=data_json, headers=valid_token_header)
 
     requests_client.get.assert_called_with(f"https://api.spotify.com/v1/albums/{album['id']}",
-                                           headers={"Authorization": valid_token_header["token"]})
+                                           headers=valid_token_header)
     pool_response = validate_response(result)
     user_pool = pool_response["users"][0]
     assert user_pool["tracks"] == []
@@ -108,10 +108,10 @@ def should_be_able_to_create_pool_from_artist(test_client: TestClient, valid_tok
     result = test_client.post("/pool", json=data_json, headers=valid_token_header)
 
     assert requests_client.get.call_args_list[0] == call(f"https://api.spotify.com/v1/artists/{artist['id']}",
-                                                         headers={"Authorization": valid_token_header["token"]})
+                                                         headers=valid_token_header)
     assert (requests_client.get.call_args_list[1]
             == call(f"https://api.spotify.com/v1/artists/{artist['id']}/top-tracks",
-                    headers={"Authorization": valid_token_header["token"]}))
+                    headers=valid_token_header))
     pool_response = validate_response(result)
     user_pool = pool_response["users"][0]
     assert user_pool["tracks"] == []
@@ -156,7 +156,7 @@ def should_be_able_to_create_pool_from_playlist(test_client: TestClient, valid_t
     result = test_client.post("/pool", json=data_json, headers=valid_token_header)
 
     requests_client.get.assert_called_with(f"https://api.spotify.com/v1/playlists/{playlist['id']}",
-                                           headers={"Authorization": valid_token_header["token"]})
+                                           headers=valid_token_header)
     pool_response = validate_response(result)
     user_pool = pool_response["users"][0]
     assert user_pool["tracks"] == []
@@ -267,4 +267,4 @@ def should_fetch_multiple_times_if_playlist_is_too_long_to_fetch_in_one_go(test_
                                            .options(joinedload(PoolMember.children)))
     assert actual_parent.name == playlist["name"]
     assert len(actual_parent.children) == playlist_length
-    assert requests_client.get.call_args.kwargs["headers"]["Authorization"] == valid_token_header["token"]
+    assert requests_client.get.call_args.kwargs["headers"] == valid_token_header

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -121,7 +121,7 @@ async def should_add_song_to_playback_if_state_next_song_is_under_two_seconds_aw
     assert actual_call.args[0].startswith("https://api.spotify.com/v1/me/player/queue")
     called_uri = get_query_parameter(actual_call.args[0], "uri")
     assert called_uri in [track["uri"] for track in existing_playback]
-    assert actual_call.kwargs["headers"]["Authorization"] == valid_token_header["token"]
+    assert actual_call.kwargs["headers"] == valid_token_header
 
 
 def should_not_add_song_to_playback_if_state_next_song_is_over_two_seconds_away(existing_playback, monkeypatch,
@@ -146,7 +146,7 @@ def should_not_add_song_to_playback_if_state_next_song_is_over_two_seconds_away(
 async def should_inactivate_sessions_for_logged_out_users(db_connection, playback_service, existing_playback,
                                                     valid_token_header, mock_token_holder: TokenHolder,
                                                     logged_in_user_id, fixed_track_length_ms, monkeypatch):
-    mock_token_holder.log_out(valid_token_header["token"])
+    mock_token_holder.log_out(valid_token_header["Authorization"])
 
     delta_to_soon = datetime.timedelta(milliseconds=(fixed_track_length_ms - 1000))
     soon = datetime.datetime.now() + delta_to_soon
@@ -173,7 +173,7 @@ def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_ser
                                                      create_mock_track_search_result, build_success_response,
                                                      requests_client, create_pool_creation_data_json, test_client,
                                                      primary_user_token):
-    mock_token_holder.log_out(valid_token_header["token"])
+    mock_token_holder.log_out(valid_token_header["Authorization"])
 
     delta_to_soon = datetime.timedelta(milliseconds=(fixed_track_length_ms - 1000))
     soon = datetime.datetime.now() + delta_to_soon
@@ -212,6 +212,6 @@ def should_be_able_to_skip_song_with_skip_route(existing_playback, valid_token_h
     assert actual_queue_call.args[0].startswith("https://api.spotify.com/v1/me/player/queue")
     called_uri = get_query_parameter(actual_queue_call.args[0], "uri")
     assert called_uri in [track["uri"] for track in existing_playback]
-    assert actual_queue_call.kwargs["headers"]["Authorization"] == valid_token_header["token"]
+    assert actual_queue_call.kwargs["headers"] == valid_token_header
     assert actual_skip_call.args[0].startswith("https://api.spotify.com/v1/me/player/next")
-    assert actual_skip_call.kwargs["headers"]["Authorization"] == valid_token_header["token"]
+    assert actual_skip_call.kwargs["headers"] == valid_token_header

--- a/server/test/pool_features/playback_websocket_features.py
+++ b/server/test/pool_features/playback_websocket_features.py
@@ -20,7 +20,7 @@ async def should_send_update_when_scheduled_queue_job_updates_playback(test_clie
             return soon if tz_info is None else soon_utc
 
     monkeypatch.setattr(datetime, "datetime", MockDateTime)
-    with test_client.websocket_connect(f"/pool/playback/register_listener?token={valid_token}") as websocket:
+    with test_client.websocket_connect(f"/pool/playback/register_listener?Authorization={valid_token}") as websocket:
         await queue_next_songs(playback_service)
         data = websocket.receive_json()
         model_data = data["model"]
@@ -34,7 +34,7 @@ def should_send_update_when_other_user_in_pool_skips(test_client, existing_playb
                                                      valid_token, shared_pool_code, validate_response,
                                                      valid_token_header):
     test_client.post(f"/pool/join/{shared_pool_code}?token={valid_token}")
-    with test_client.websocket_connect(f"/pool/playback/register_listener?token={valid_token}") as websocket:
+    with test_client.websocket_connect(f"/pool/playback/register_listener?Authorization={valid_token}") as websocket:
         response = test_client.post("/pool/playback/skip", headers=valid_token_header)
         result = validate_response(response)
         data = websocket.receive_json()

--- a/server/test/pool_features/pool_websocket_features.py
+++ b/server/test/pool_features/pool_websocket_features.py
@@ -9,7 +9,8 @@ def should_get_update_when_pool_contents_added(test_client, valid_token_header, 
                                                create_mock_playlist_fetch_result, requests_client,
                                                another_logged_in_user_token):
     test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
-    with test_client.websocket_connect(f"/pool/register_listener?token={another_logged_in_user_token}") as websocket:
+    with test_client.websocket_connect(
+            f"/pool/register_listener?Authorization={another_logged_in_user_token}") as websocket:
         playlist = create_mock_playlist_fetch_result(15)
         requests_client.get = Mock(return_value=build_success_response(playlist))
         pool_content_data = PoolContent(spotify_uri=playlist["uri"]).model_dump()
@@ -24,7 +25,8 @@ def should_get_update_when_pool_contents_deleted(test_client, valid_token_header
                                                  another_logged_in_user_header, logged_in_user_id, existing_playback,
                                                  another_logged_in_user_token):
     test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
-    with test_client.websocket_connect(f"/pool/register_listener?token={another_logged_in_user_token}") as websocket:
+    with test_client.websocket_connect(
+            f"/pool/register_listener?Authorization={another_logged_in_user_token}") as websocket:
         deleted_song = random.choice(existing_playback)
         test_client.delete(f"/pool/content/{deleted_song["uri"]}", headers=valid_token_header)
         data = websocket.receive_json()
@@ -35,7 +37,7 @@ def should_get_update_when_pool_contents_deleted(test_client, valid_token_header
 
 def should_get_update_when_user_joins_pool(test_client, valid_token, shared_pool_code, existing_playback,
                                            another_logged_in_user_header):
-    with test_client.websocket_connect(f"/pool/register_listener?token={valid_token}") as websocket:
+    with test_client.websocket_connect(f"/pool/register_listener?Authorization={valid_token}") as websocket:
         test_client.post(f"/pool/join/{shared_pool_code}", headers=another_logged_in_user_header)
         data = websocket.receive_json()
         assert len(data["model"]["users"]) == 2

--- a/server/test/search_features/album_search_features.py
+++ b/server/test/search_features/album_search_features.py
@@ -32,7 +32,7 @@ def should_query_spotify_for_albums_with_provided_query_string(test_client, vali
     requests_client.get = Mock(return_value=create_album_paginated_search(query))
     test_client.get(f"/search/albums?query={query}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=album&offset=0&limit=20"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
 
 
 def should_return_less_results_if_twenty_not_found(test_client, valid_token_header, validate_response, requests_client,
@@ -54,6 +54,6 @@ def should_use_offset_and_limit_if_provided(test_client, valid_token_header, req
     requests_client.get = Mock(return_value=create_album_paginated_search(query, limit))
     result = test_client.get(f"/search/albums?query={query}&offset={offset}&limit={limit}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=album&offset={offset}&limit={limit}"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
     search_result = validate_response(result)
     validate_paginated_result_length(search_result, limit)

--- a/server/test/search_features/artist_search_features.py
+++ b/server/test/search_features/artist_search_features.py
@@ -31,7 +31,7 @@ def should_query_spotify_for_artists_with_provided_query_string(test_client, val
     requests_client.get = Mock(return_value=create_artist_paginated_search(query))
     test_client.get(f"/search/artists?query={query}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=artist&offset=0&limit=20"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
 
 
 def should_return_less_results_if_twenty_not_found(test_client, valid_token_header, validate_response, requests_client,
@@ -53,6 +53,6 @@ def should_use_offset_and_limit_if_provided(test_client, valid_token_header, req
     requests_client.get = Mock(return_value=create_artist_paginated_search(query, limit))
     result = test_client.get(f"/search/artists?query={query}&offset={offset}&limit={limit}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=artist&offset={offset}&limit={limit}"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
     search_result = validate_response(result)
     validate_paginated_result_length(search_result, limit)

--- a/server/test/search_features/general_search_features.py
+++ b/server/test/search_features/general_search_features.py
@@ -59,7 +59,7 @@ def should_call_spotify_with_the_provided_query(test_client, valid_token_header,
     test_client.get(f"/search?query={query}", headers=valid_token_header)
     types = ",".join(["track", "album", "artist", "playlist"])
     full_query = f"https://api.spotify.com/v1/search?q={query}&type={types}&offset=0&limit=20"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
 
 
 def should_return_largest_image(test_client, valid_token_header, mock_spotify_general_search, validate_response,

--- a/server/test/search_features/playlist_search_features.py
+++ b/server/test/search_features/playlist_search_features.py
@@ -31,7 +31,7 @@ def should_query_spotify_for_playlists_with_provided_query_string(test_client, v
     requests_client.get = Mock(return_value=create_playlist_paginated_search(query))
     test_client.get(f"/search/playlists?query={query}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=playlist&offset=0&limit=20"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
 
 
 def should_return_less_results_if_twenty_not_found(test_client, valid_token_header, validate_response, requests_client,
@@ -53,6 +53,6 @@ def should_use_offset_and_limit_if_provided(test_client, valid_token_header, req
     requests_client.get = Mock(return_value=create_playlist_paginated_search(query, limit))
     result = test_client.get(f"/search/playlists?query={query}&offset={offset}&limit={limit}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=playlist&offset={offset}&limit={limit}"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
     search_result = validate_response(result)
     validate_paginated_result_length(search_result, limit)

--- a/server/test/search_features/track_search_features.py
+++ b/server/test/search_features/track_search_features.py
@@ -31,7 +31,7 @@ def should_query_spotify_for_tracks_with_provided_query_string(test_client, vali
     requests_client.get = Mock(return_value=create_track_paginated_search(query))
     test_client.get(f"/search/tracks?query={query}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=track&offset=0&limit=20"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
 
 
 def should_return_less_results_if_twenty_not_found(test_client, valid_token_header, validate_response, requests_client,
@@ -53,6 +53,6 @@ def should_use_offset_and_limit_if_provided(test_client, valid_token_header, req
     requests_client.get = Mock(return_value=create_track_paginated_search(query, limit))
     result = test_client.get(f"/search/tracks?query={query}&offset={offset}&limit={limit}", headers=valid_token_header)
     full_query = f"https://api.spotify.com/v1/search?q={query}&type=track&offset={offset}&limit={limit}"
-    requests_client.get.assert_called_with(full_query, headers={"Authorization": valid_token_header["token"]})
+    requests_client.get.assert_called_with(full_query, headers=valid_token_header)
     search_result = validate_response(result)
     validate_paginated_result_length(search_result, limit)


### PR DESCRIPTION
While this is not strictly required for it, this creates nice consistency with the upcoming refresh token implementation so I just went ahead and did this.