### PR TITLE
199 subtask include users current token in all authorized response headers and refresh expired tokens on token validation in backend

### DIFF
--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -168,12 +168,13 @@ async def should_inactivate_sessions_for_logged_out_users(db_connection, playbac
     assert not playback_state.is_active
 
 
-def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_service, existing_playback,
-                                                     valid_token_header, mock_token_holder: TokenHolder,
-                                                     logged_in_user, fixed_track_length_ms, monkeypatch,
-                                                     create_mock_track_search_result, build_success_response,
-                                                     requests_client, create_pool_creation_data_json, test_client,
-                                                     primary_user_token):
+@pytest.mark.asyncio
+async def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_service, existing_playback,
+                                                           valid_token_header, mock_token_holder: TokenHolder,
+                                                           logged_in_user, fixed_track_length_ms, monkeypatch,
+                                                           create_mock_track_search_result, build_success_response,
+                                                           requests_client, create_pool_creation_data_json, test_client,
+                                                           primary_user_token):
     mock_token_holder.log_out(valid_token_header["Authorization"])
 
     delta_to_soon = datetime.timedelta(milliseconds=(fixed_track_length_ms - 1000))
@@ -186,7 +187,7 @@ def should_reactivate_inactive_playback_on_post_pool(db_connection, playback_ser
             return soon if tz_info is None else soon_utc
 
     monkeypatch.setattr(datetime, "datetime", MockDateTime)
-    queue_next_songs(playback_service)
+    await queue_next_songs(playback_service)
     AuthDatabaseConnection(db_connection).update_logged_in_user(logged_in_user, primary_user_token)
 
     tracks = [create_mock_track_search_result() for _ in range(1)]


### PR DESCRIPTION
Backend now sends identical Authorization header containing current (fresh) user spotify token with every response.