### PR TITLE
206 spotify responses with no content cause core to error

### DIFF
--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -50,7 +50,8 @@ RequestsClient = Annotated[RequestsClientRaw, Depends()]
 
 
 def _validate_and_decode(response: Response) -> dict:
-    parsed_data = json.loads(response.content.decode("utf8"))
+    response_string = response.content.decode("utf8")
+    parsed_data = json.loads(response_string) if response_string else None
     if response.status_code >= 400:
         error_message = (f"Error code {response.status_code} received while calling Spotify API. "
                          f"Message: {parsed_data["error"]}")

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -11,6 +11,14 @@ from database.database_connection import ConnectionManager
 from database.entities import PoolMember
 
 
+@pytest.fixture(autouse=True)
+def mock_put_response(requests_client):
+    response = Mock()
+    response.status_code = 200
+    response.content = "".encode("utf-8")
+    requests_client.put = Mock(return_value=response)
+
+
 def should_create_pool_of_one_song_when_post_pool_called_with_single_song_id(test_client: TestClient,
                                                                              valid_token_header,
                                                                              validate_response,
@@ -21,6 +29,7 @@ def should_create_pool_of_one_song_when_post_pool_called_with_single_song_id(tes
     my_track = create_mock_track_search_result()
     data_json = create_pool_creation_data_json(my_track["uri"])
     requests_client.get = Mock(return_value=build_success_response(my_track))
+    requests_client.put = Mock(return_value=build_success_response(""))
     response = test_client.post("/pool", json=data_json, headers=valid_token_header)
     pool_response = validate_response(response)
     assert pool_response["users"][0]["tracks"][0]["name"] == my_track["name"]

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -29,7 +29,6 @@ def should_create_pool_of_one_song_when_post_pool_called_with_single_song_id(tes
     my_track = create_mock_track_search_result()
     data_json = create_pool_creation_data_json(my_track["uri"])
     requests_client.get = Mock(return_value=build_success_response(my_track))
-    requests_client.put = Mock(return_value=build_success_response(""))
     response = test_client.post("/pool", json=data_json, headers=valid_token_header)
     pool_response = validate_response(response)
     assert pool_response["users"][0]["tracks"][0]["name"] == my_track["name"]


### PR DESCRIPTION
Added autouse fixture for pool creation tests that mocks the spotify response data that PUT queue route returns. Fixed problem - tests pass