### PR TITLE
Changed front docker to use 3000 port again

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -59,9 +59,9 @@ COPY --from=builder /app/entrypoint.sh ./entrypoint.sh
 
 USER nextjs
 
-EXPOSE 80
+EXPOSE 3000
 
-ENV PORT 80
+ENV PORT 3000
 # set hostname to localhost
 ENV HOSTNAME "0.0.0.0"
 

--- a/client/README.md
+++ b/client/README.md
@@ -94,7 +94,7 @@ simple as entering the following commands in the project root.
 
 ```bash
 docker build -t stagnum-client ./client
-docker run -p 80:80 stagnum-client
+docker run -p 80:3000 stagnum-client
 ```
 
 Open [localhost](http://localhost:80) with your browser to verify that the client is running.


### PR DESCRIPTION
Change front docker to use port 3000 again. This is due that port 1-1024 need administrator privileges or special configs from the host machine. 

This needs to be changed for any cloud deployments to work.