### PR TITLE
#416 Fix searches expecing all items to be non-nullable

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -52,8 +52,6 @@ select = [
 ]
 ignore = [
     "COM812", # trailing comma
-    "ANN101", # type annotation for self
-    "ANN102", # type annotation for cls
     "PLR0913", # too many arguments in function definition - should not be automatically enforced but left to user
 ]
 unfixable = [

--- a/server/src/alembic/env.py
+++ b/server/src/alembic/env.py
@@ -1,9 +1,10 @@
 import os
 from logging.config import fileConfig
 
+from sqlalchemy import engine_from_config, pool
+
 import database.entities
 from alembic import context
-from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/server/src/alembic/versions/149e2197ecff_add_data_required_for_login_and_auth_.py
+++ b/server/src/alembic/versions/149e2197ecff_add_data_required_for_login_and_auth_.py
@@ -6,9 +6,11 @@ Create Date: 2024-02-04 16:03:08.775667
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/1dc141893e67_add_support_for_promoting_tracks.py
+++ b/server/src/alembic/versions/1dc141893e67_add_support_for_promoting_tracks.py
@@ -6,9 +6,11 @@ Create Date: 2024-07-04 20:46:31.321412
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/25c34e5bf930_data_changes_required_for_pool_.py
+++ b/server/src/alembic/versions/25c34e5bf930_data_changes_required_for_pool_.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-30 14:12:03.885924
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/27048d682757_make_user_icon_url_nullable.py
+++ b/server/src/alembic/versions/27048d682757_make_user_icon_url_nullable.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-17 21:41:39.600945
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/3b8805c4d7db_fixing_incorrect_foreign_keys.py
+++ b/server/src/alembic/versions/3b8805c4d7db_fixing_incorrect_foreign_keys.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-05 15:18:51.744044
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/4fc5f9bc5558_double_avatar_url_length.py
+++ b/server/src/alembic/versions/4fc5f9bc5558_double_avatar_url_length.py
@@ -6,9 +6,11 @@ Create Date: 2024-04-14 20:05:43.487023
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/62ec829ee3f3_caching_current_song_playback_data_in_.py
+++ b/server/src/alembic/versions/62ec829ee3f3_caching_current_song_playback_data_in_.py
@@ -6,9 +6,11 @@ Create Date: 2024-04-01 23:48:12.772757
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/6b917dddd71e_add_model_for_pool_members.py
+++ b/server/src/alembic/versions/6b917dddd71e_add_model_for_pool_members.py
@@ -6,9 +6,11 @@ Create Date: 2024-02-17 19:31:08.955617
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/70e02357c5ff_big_changes_for_support_for_pool_.py
+++ b/server/src/alembic/versions/70e02357c5ff_big_changes_for_support_for_pool_.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-22 22:58:29.691236
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/7851701cd257_add_playback_status_entity.py
+++ b/server/src/alembic/versions/7851701cd257_add_playback_status_entity.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-03 10:41:34.028762
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/a864a5084871_new_field_for_user_session_for_storing_.py
+++ b/server/src/alembic/versions/a864a5084871_new_field_for_user_session_for_storing_.py
@@ -6,9 +6,11 @@ Create Date: 2024-04-11 18:01:39.893767
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/aeb0c7f142d6_increase_field_sizes_for_pool_members.py
+++ b/server/src/alembic/versions/aeb0c7f142d6_increase_field_sizes_for_pool_members.py
@@ -6,9 +6,11 @@ Create Date: 2024-03-17 13:25:12.253269
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/alembic/versions/af9978211950_add_user_table.py
+++ b/server/src/alembic/versions/af9978211950_add_user_table.py
@@ -6,9 +6,11 @@ Create Date: 2024-01-28 16:36:29.976955
 
 """
 
-from typing import Sequence, Union
+from collections.abc import Sequence
+from typing import Union
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/server/src/api/application.py
+++ b/server/src/api/application.py
@@ -1,6 +1,6 @@
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from logging import getLogger
-from typing import AsyncGenerator
 
 from apscheduler.jobstores.memory import MemoryJobStore
 from apscheduler.schedulers.asyncio import AsyncIOScheduler

--- a/server/src/api/auth/dependencies.py
+++ b/server/src/api/auth/dependencies.py
@@ -2,7 +2,6 @@ import datetime
 from logging import getLogger
 from typing import Annotated, Optional
 
-from database.entities import LoginState, User, UserSession
 from fastapi import Depends, HTTPException
 from sqlalchemy import delete, select
 
@@ -10,6 +9,7 @@ from api.auth.models import LoginRedirect, LoginSuccess
 from api.common.dependencies import AuthSpotifyClient, DatabaseConnection, DateTimeWrapper, TokenHolder
 from api.common.helpers import _get_client_id, _get_client_secret, create_random_string
 from api.common.models import ParsedTokenResponse
+from database.entities import LoginState, User, UserSession
 
 _logger = getLogger("main.api.auth.dependencies")
 

--- a/server/src/api/auth/dependencies.py
+++ b/server/src/api/auth/dependencies.py
@@ -85,7 +85,7 @@ class AuthServiceRaw:
         if not self._database_connection.is_valid_state(state):
             _logger.error(f"Invalid login attempt! Did not find state string that matches state {state}.")
             error_message = (
-                "Login state is invalid or expired. " "Please restart the login flow to ensure a fresh and valid state."
+                "Login state is invalid or expired. Please restart the login flow to ensure a fresh and valid state."
             )
             raise HTTPException(status_code=403, detail=error_message)
 

--- a/server/src/api/auth/tasks.py
+++ b/server/src/api/auth/tasks.py
@@ -1,10 +1,9 @@
 import datetime
 from logging import getLogger
 
-from database.database_connection import ConnectionManager
-
 from api.auth.dependencies import AuthDatabaseConnection
 from api.common.dependencies import DateTimeWrapper
+from database.database_connection import ConnectionManager
 
 _logger = getLogger("main.api.auth.tasks")
 

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -7,8 +7,6 @@ from logging import getLogger
 from typing import Annotated, Any, Optional
 
 import requests
-from database.database_connection import ConnectionManager
-from database.entities import User, UserSession
 from fastapi import Depends, Header, HTTPException
 from fastapi import Response as FastAPIResponse
 from requests import Response as RequestsResponse
@@ -18,6 +16,8 @@ from starlette import status
 from api.common.helpers import _get_client_id, _get_client_secret
 from api.common.models import SpotifyTokenResponse
 from api.common.spotify_models import RefreshTokenData, RequestTokenData
+from database.database_connection import ConnectionManager
+from database.entities import User, UserSession
 
 _logger = getLogger("main.api.common.dependencies")
 

--- a/server/src/api/common/dependencies.py
+++ b/server/src/api/common/dependencies.py
@@ -53,7 +53,7 @@ class RequestsClientRaw:  # pragma: no cover - we're always mocking this class
         result = requests.get(*args, **kwargs)
         _logger.info(
             f"Call result: {result.status_code} ; "
-            f"{result.content[: self._LINE_CUTOFF]}{"..." if len(result.content) > self._LINE_CUTOFF else ""}"
+            f"{result.content[: self._LINE_CUTOFF]}{'...' if len(result.content) > self._LINE_CUTOFF else ''}"
         )
         return result
 
@@ -63,7 +63,7 @@ class RequestsClientRaw:  # pragma: no cover - we're always mocking this class
         result = requests.post(*args, **kwargs)
         _logger.info(
             f"Call result: {result.status_code} ; "
-            f"{result.content[: self._LINE_CUTOFF]}{"..." if len(result.content) > self._LINE_CUTOFF else ""}"
+            f"{result.content[: self._LINE_CUTOFF]}{'...' if len(result.content) > self._LINE_CUTOFF else ''}"
         )
         return result
 
@@ -73,7 +73,7 @@ class RequestsClientRaw:  # pragma: no cover - we're always mocking this class
         result = requests.put(*args, **kwargs)
         _logger.info(
             f"Call result: {result.status_code} ; "
-            f"{result.content[: self._LINE_CUTOFF]}{"..." if len(result.content) > self._LINE_CUTOFF else ""}"
+            f"{result.content[: self._LINE_CUTOFF]}{'...' if len(result.content) > self._LINE_CUTOFF else ''}"
         )
         return result
 
@@ -91,7 +91,7 @@ def _validate_and_decode(response: RequestsResponse) -> dict[str, Any] | None:
         parsed_data = None
     if response.status_code >= status.HTTP_400_BAD_REQUEST:
         error_message = (
-            f"Error code {response.status_code} received while calling Spotify API. " f"Message: {parsed_data["error"]}"
+            f"Error code {response.status_code} received while calling Spotify API. Message: {parsed_data['error']}"
         )
         raise HTTPException(status_code=502, detail=error_message)
     return parsed_data

--- a/server/src/api/common/helpers.py
+++ b/server/src/api/common/helpers.py
@@ -4,10 +4,10 @@ import string
 from logging import getLogger
 from typing import Never
 
-from database.entities import User
 from fastapi import HTTPException
 
 from api.common.models import PoolJoinedUser, UserModel
+from database.entities import User
 
 _logger = getLogger("main.api.common.helpers")
 

--- a/server/src/api/common/spotify_models.py
+++ b/server/src/api/common/spotify_models.py
@@ -45,7 +45,7 @@ class PaginatedSearchResultData[ResultType: SpotifyResourceData](TypedDict):
     offset: int
     previous: str | None
     total: int
-    items: list[ResultType]
+    items: list[ResultType | None]
 
 
 class ArtistData(SpotifyResourceWithImagesData):

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -905,7 +905,7 @@ class PoolPlaybackServiceRaw:
         while len(queue_data) > 0:
             has_skipped_songs = True
             for track_data in queue_data:
-                _logger.info(f"Skipping track {track_data["name"]} from user {user.spotify_username} queue.")
+                _logger.info(f"Skipping track {track_data['name']} from user {user.spotify_username} queue.")
                 self._spotify_client.skip_current_song(user)
             queue_data = _get_additional_queue_part(self._spotify_client.get_user_queue(user))
 

--- a/server/src/api/pool/dependencies.py
+++ b/server/src/api/pool/dependencies.py
@@ -2,15 +2,6 @@ import datetime
 from logging import getLogger
 from typing import Annotated, Any, ClassVar, Literal, Optional
 
-from database.entities import (
-    PlaybackSession,
-    Pool,
-    PoolJoinedUser,
-    PoolMember,
-    PoolMemberRandomizationParameters,
-    PoolShareData,
-    User,
-)
 from fastapi import Depends, HTTPException, WebSocket
 from sqlalchemy import and_, delete, exists, or_, select, update
 from sqlalchemy.orm import Session, joinedload
@@ -35,6 +26,15 @@ from api.pool.models import (
 from api.pool.models import PoolMember as PoolMemberModel
 from api.pool.randomization_algorithms import NextSongProvider
 from api.pool.spotify_models import PlaybackStateData, QueueData
+from database.entities import (
+    PlaybackSession,
+    Pool,
+    PoolJoinedUser,
+    PoolMember,
+    PoolMemberRandomizationParameters,
+    PoolShareData,
+    User,
+)
 
 _logger = getLogger("main.api.pool.dependencies")
 _PLAYBACK_UPDATE_CUTOFF_MS = 3000

--- a/server/src/api/pool/helpers.py
+++ b/server/src/api/pool/helpers.py
@@ -1,9 +1,8 @@
 from logging import getLogger
 
-from database.entities import PoolMember, User
-
 from api.common.helpers import map_user_entity_to_joined_user_model
 from api.pool.models import PoolCollection, PoolFullContents, PoolTrack, PoolUserContents, UnsavedPoolTrack
+from database.entities import PoolMember, User
 
 _logger = getLogger("main.api.pool.helpers")
 

--- a/server/src/api/pool/randomization_algorithms.py
+++ b/server/src/api/pool/randomization_algorithms.py
@@ -3,8 +3,9 @@ import random
 from dataclasses import dataclass
 from typing import Annotated
 
-from database.entities import PoolMember, User
 from fastapi import Depends
+
+from database.entities import PoolMember, User
 
 
 @dataclass

--- a/server/src/api/pool/routes.py
+++ b/server/src/api/pool/routes.py
@@ -1,12 +1,12 @@
 from logging import getLogger
 
-from database.entities import PoolMember, User
 from fastapi import APIRouter
 
 from api.common.dependencies import validated_user
 from api.pool.dependencies import PoolDatabaseConnection, PoolPlaybackService, PoolSpotifyClient, WebsocketUpdater
 from api.pool.helpers import create_pool_return_model
 from api.pool.models import PoolContent, PoolCreationData, PoolFullContents, UnsavedPoolTrack
+from database.entities import PoolMember, User
 
 _logger = getLogger("main.api.pool.routes")
 

--- a/server/src/api/pool/tasks.py
+++ b/server/src/api/pool/tasks.py
@@ -1,7 +1,5 @@
 from logging import getLogger
 
-from database.database_connection import ConnectionManager
-
 from api.common.dependencies import (
     AuthSpotifyClient,
     DateTimeWrapper,
@@ -12,6 +10,7 @@ from api.common.dependencies import (
 )
 from api.pool.dependencies import PoolDatabaseConnection, PoolPlaybackService, PoolSpotifyClient, WebsocketUpdater
 from api.pool.randomization_algorithms import NextSongProvider
+from database.database_connection import ConnectionManager
 
 _logger = getLogger("main.api.pool.tasks")
 

--- a/server/src/api/search/dependencies.py
+++ b/server/src/api/search/dependencies.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 from typing import Annotated
 
-from database.entities import User
 from fastapi import Depends, HTTPException
 
 from api.common.dependencies import SpotifyClient
@@ -22,6 +21,7 @@ from api.search.models import (
     TrackSearchResult,
 )
 from api.search.spotify_models import GeneralSearchResultData
+from database.entities import User
 
 _logger = getLogger("main.api.search.dependencies")
 

--- a/server/src/api/search/dependencies.py
+++ b/server/src/api/search/dependencies.py
@@ -56,7 +56,7 @@ def _build_paginated_track_search(result_data: PaginatedSearchResultData[TrackDa
         limit=result_data["limit"],
         offset=result_data["offset"],
         total=result_data["total"],
-        items=[_build_track(track) for track in result_data["items"]],
+        items=[_build_track(track) for track in result_data["items"] if track is not None],
         self_page_link=result_data["href"],
         next_page_link=result_data["next"],
     )
@@ -76,7 +76,7 @@ def _build_paginated_artist_search(result_data: PaginatedSearchResultData[Artist
         limit=result_data["limit"],
         offset=result_data["offset"],
         total=result_data["total"],
-        items=[_build_artist(artist) for artist in result_data["items"]],
+        items=[_build_artist(artist) for artist in result_data["items"] if artist is not None],
         self_page_link=result_data["href"],
         next_page_link=result_data["next"],
     )
@@ -101,7 +101,7 @@ def _build_paginated_album_search(result_data: PaginatedSearchResultData[AlbumDa
         limit=result_data["limit"],
         offset=result_data["offset"],
         total=result_data["total"],
-        items=[_build_album(album) for album in result_data["items"]],
+        items=[_build_album(album) for album in result_data["items"] if album is not None],
         self_page_link=result_data["href"],
         next_page_link=result_data["next"],
     )
@@ -121,7 +121,7 @@ def _build_paginated_playlist_search(result_data: PaginatedSearchResultData[Play
         limit=result_data["limit"],
         offset=result_data["offset"],
         total=result_data["total"],
-        items=[_build_playlist(playlist) for playlist in result_data["items"]],
+        items=[_build_playlist(playlist) for playlist in result_data["items"] if playlist is not None],
         self_page_link=result_data["href"],
         next_page_link=result_data["next"],
     )

--- a/server/src/api/search/routes.py
+++ b/server/src/api/search/routes.py
@@ -30,9 +30,7 @@ async def search(query: str, user: validated_user, spotify_client: SearchSpotify
 async def search_tracks(
     user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0, limit: int = 20
 ) -> TrackSearchResult:
-    _logger.debug(
-        f"GET /search/tracks called with query '{query}', " f"offset {offset}, limit {limit} and token '{user}'."
-    )
+    _logger.debug(f"GET /search/tracks called with query '{query}', offset {offset}, limit {limit} and token '{user}'.")
     return spotify_client.get_track_search(query, user, offset, limit)
 
 
@@ -40,9 +38,7 @@ async def search_tracks(
 async def search_albums(
     user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0, limit: int = 20
 ) -> AlbumSearchResult:
-    _logger.debug(
-        f"GET /search/albums called with query '{query}', " f"offset {offset}, limit {limit} and token '{user}'."
-    )
+    _logger.debug(f"GET /search/albums called with query '{query}', offset {offset}, limit {limit} and token '{user}'.")
     return spotify_client.get_album_search(query, user, offset, limit)
 
 
@@ -51,7 +47,7 @@ async def search_artists(
     user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0, limit: int = 20
 ) -> ArtistSearchResult:
     _logger.debug(
-        f"GET /search/artists called with query '{query}', " f"offset {offset}, limit {limit} and token '{user}'."
+        f"GET /search/artists called with query '{query}', offset {offset}, limit {limit} and token '{user}'."
     )
     return spotify_client.get_artist_search(query, user, offset, limit)
 
@@ -61,6 +57,6 @@ async def search_playlists(
     user: validated_user, spotify_client: SearchSpotifyClient, query: str, offset: int = 0, limit: int = 20
 ) -> PlaylistSearchResult:
     _logger.debug(
-        f"GET /search/playlists called with query '{query}', " f"offset {offset}, limit {limit} and token '{user}'."
+        f"GET /search/playlists called with query '{query}', offset {offset}, limit {limit} and token '{user}'."
     )
     return spotify_client.get_playlist_search(query, user, offset, limit)

--- a/server/src/database/database_connection.py
+++ b/server/src/database/database_connection.py
@@ -1,7 +1,6 @@
 import os
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from logging import getLogger
-from typing import ContextManager
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.exc import SQLAlchemyError
@@ -44,7 +43,7 @@ class ConnectionManager:
         return cls._sqlite_in_memory_engine
 
     @contextmanager
-    def session(self) -> ContextManager[Session]:
+    def session(self) -> AbstractContextManager[Session]:
         context_session = self._session()
         _logger.debug(f"Created a database session with hash {context_session.hash_key}")
         try:

--- a/server/test/auth_features/auth_login_callback_features.py
+++ b/server/test/auth_features/auth_login_callback_features.py
@@ -49,7 +49,7 @@ def should_return_exception_if_state_is_not_in_database_on_auth_callback(
     test_client: TestClient, validate_error_response: ValidateErrorResponse
 ) -> None:
     response = test_client.get(
-        "/auth/login/callback?state=my_invalid_state&code=12345abcde" "&client_redirect_uri=test_url"
+        "/auth/login/callback?state=my_invalid_state&code=12345abcde&client_redirect_uri=test_url"
     )
     message = "Login state is invalid or expired. Please restart the login flow to ensure a fresh and valid state."
     validate_error_response(response, 403, message)
@@ -101,7 +101,7 @@ def should_include_code_from_query_in_spotify_api_request(
 ) -> None:
     expected_code = "my_auth_code"
     test_client.get(
-        f"/auth/login/callback?state={primary_valid_state_string}" f"&code={expected_code}&client_redirect_uri=test_url"
+        f"/auth/login/callback?state={primary_valid_state_string}&code={expected_code}&client_redirect_uri=test_url"
     )
     call = requests_client.post.call_args
     assert call.kwargs["data"]["code"] == expected_code
@@ -113,8 +113,7 @@ def should_include_redirect_url_from_query_in_spotify_api_request(
 ) -> None:
     expected_url = "my_redirect_url"
     test_client.get(
-        f"/auth/login/callback?state={primary_valid_state_string}"
-        f"&code=12345abcde&client_redirect_uri={expected_url}"
+        f"/auth/login/callback?state={primary_valid_state_string}&code=12345abcde&client_redirect_uri={expected_url}"
     )
     call = requests_client.post.call_args
     assert call.kwargs["data"]["redirect_uri"] == expected_url

--- a/server/test/auth_features/auth_login_callback_features.py
+++ b/server/test/auth_features/auth_login_callback_features.py
@@ -3,9 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from api.common.dependencies import TokenHolder, validated_user_raw
-from database.database_connection import ConnectionManager
-from database.entities import LoginState, User
 from fastapi import HTTPException
 from helpers.classes import ErrorData, SubscriptionType
 from sqlalchemy import select
@@ -21,6 +18,10 @@ from test_types.callables import (
     ValidateErrorResponse,
     ValidateResponse,
 )
+
+from api.common.dependencies import TokenHolder, validated_user_raw
+from database.database_connection import ConnectionManager
+from database.entities import LoginState, User
 
 
 @pytest.fixture

--- a/server/test/auth_features/auth_login_features.py
+++ b/server/test/auth_features/auth_login_features.py
@@ -34,7 +34,7 @@ def should_have_sixteen_bytes_of_noise_as_state_in_login_redirect_response(
     data_json = validate_response(response)
     state_string = get_query_parameter(data_json["redirect_uri"], "state")
     assert re.match(r"\w{16}", state_string), (
-        f"State string '{state_string}' does not consist of sixteen " f"digits or letters"
+        f"State string '{state_string}' does not consist of sixteen digits or letters"
     )
 
 

--- a/server/test/auth_features/auth_login_features.py
+++ b/server/test/auth_features/auth_login_features.py
@@ -2,11 +2,12 @@ import re
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from api.common.dependencies import DatabaseConnection
-from database.entities import LoginState
 from sqlalchemy import select
 from starlette.testclient import TestClient
 from test_types.callables import BaseAuthLogin, GetQueryParameter, ValidateResponse
+
+from api.common.dependencies import DatabaseConnection
+from database.entities import LoginState
 
 
 @pytest.fixture

--- a/server/test/auth_features/cleanup_state_strings_features.py
+++ b/server/test/auth_features/cleanup_state_strings_features.py
@@ -1,13 +1,14 @@
 import datetime
 
 import pytest
+from helpers.classes import MockDateTimeWrapper
+from sqlalchemy import select
+from test_types.callables import IncrementNow
+
 from api.auth.dependencies import AuthDatabaseConnectionRaw
 from api.auth.tasks import cleanup_state_strings
 from database.database_connection import ConnectionManager
 from database.entities import LoginState
-from helpers.classes import MockDateTimeWrapper
-from sqlalchemy import select
-from test_types.callables import IncrementNow
 
 
 @pytest.fixture

--- a/server/test/auth_features/conftest.py
+++ b/server/test/auth_features/conftest.py
@@ -8,10 +8,6 @@ import httpx
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from api.auth.spotify_models import SpotifyFetchMeData
-from api.common.spotify_models import ImageData
-from database.database_connection import ConnectionManager
-from database.entities import LoginState
 from starlette.testclient import TestClient
 from test_types.aliases import MockResponseQueue, SpotifySecrets
 from test_types.callables import (
@@ -23,6 +19,11 @@ from test_types.callables import (
     MockSpotifyUserDataFetch,
     MockTokenReturn,
 )
+
+from api.auth.spotify_models import SpotifyFetchMeData
+from api.common.spotify_models import ImageData
+from database.database_connection import ConnectionManager
+from database.entities import LoginState
 
 
 @pytest.fixture

--- a/server/test/conftest.py
+++ b/server/test/conftest.py
@@ -11,22 +11,6 @@ import pytest
 from _pytest.config import Config
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from api.application import create_app
-from api.auth.dependencies import AuthDatabaseConnection
-from api.common.dependencies import (
-    AuthSpotifyClient,
-    DateTimeWrapperRaw,
-    RequestsClient,
-    RequestsClientRaw,
-    SpotifyClient,
-    TokenHolder,
-    UserDatabaseConnection,
-)
-from api.common.models import ParsedTokenResponse
-from api.common.spotify_models import AlbumData, ArtistData, PlaylistData, TrackData
-from api.pool.models import PoolContent, PoolCreationData, PoolFullContents
-from database.database_connection import ConnectionManager
-from database.entities import PoolMember, User
 from faker import Faker
 from fastapi import FastAPI
 from helpers.classes import ErrorData, ErrorResponse, MockDateTimeWrapper, MockedArtistPoolContent, MockedPoolContents
@@ -62,6 +46,23 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers, PoolContentData, PoolCreationDataDict
+
+from api.application import create_app
+from api.auth.dependencies import AuthDatabaseConnection
+from api.common.dependencies import (
+    AuthSpotifyClient,
+    DateTimeWrapperRaw,
+    RequestsClient,
+    RequestsClientRaw,
+    SpotifyClient,
+    TokenHolder,
+    UserDatabaseConnection,
+)
+from api.common.models import ParsedTokenResponse
+from api.common.spotify_models import AlbumData, ArtistData, PlaylistData, TrackData
+from api.pool.models import PoolContent, PoolCreationData, PoolFullContents
+from database.database_connection import ConnectionManager
+from database.entities import PoolMember, User
 
 
 @pytest.fixture

--- a/server/test/framework_features.py
+++ b/server/test/framework_features.py
@@ -1,14 +1,15 @@
 import datetime
 
-from api.common.helpers import map_user_entity_to_model
-from api.common.models import UserModel
-from database.database_connection import ConnectionManager
-from database.entities import LoginState, User
 from helpers.classes import ApproxDatetime, MockDateTimeWrapper
 from sqlalchemy import select
 from starlette.testclient import TestClient
 from test_types.callables import ValidateModel
 from test_types.typed_dictionaries import Headers
+
+from api.common.helpers import map_user_entity_to_model
+from api.common.models import UserModel
+from database.database_connection import ConnectionManager
+from database.entities import LoginState, User
 
 
 def should_have_functioning_database_connection(db_connection: ConnectionManager) -> None:

--- a/server/test/healthcheck_features.py
+++ b/server/test/healthcheck_features.py
@@ -1,6 +1,7 @@
-from api.health.models import HEALTHY, HealthcheckResult
 from conftest import ValidateModel
 from starlette.testclient import TestClient
+
+from api.health.models import HEALTHY, HealthcheckResult
 
 
 def should_return_time_taken_and_healthy_status_on_normal_operation(

--- a/server/test/helpers/classes.py
+++ b/server/test/helpers/classes.py
@@ -4,9 +4,10 @@ from enum import Enum
 from typing import override
 
 from _pytest.python_api import ApproxBase
+from pydantic import BaseModel
+
 from api.common.dependencies import DateTimeWrapperRaw
 from api.common.spotify_models import AlbumData, ArtistData, PaginatedSearchResultData, PlaylistData, TrackData
-from pydantic import BaseModel
 
 
 @dataclass

--- a/server/test/pool_features/add_content_features.py
+++ b/server/test/pool_features/add_content_features.py
@@ -1,7 +1,4 @@
 import pytest
-from api.pool.models import PoolContent, PoolFullContents
-from database.database_connection import ConnectionManager
-from database.entities import PoolMember
 from helpers.classes import ErrorData, MockedPoolContents
 from sqlalchemy import and_, select
 from starlette.testclient import TestClient
@@ -20,6 +17,10 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.pool.models import PoolContent, PoolFullContents
+from database.database_connection import ConnectionManager
+from database.entities import PoolMember
 
 
 def should_create_a_pool_member_for_user_even_if_user_pool_is_empty(

--- a/server/test/pool_features/conftest.py
+++ b/server/test/pool_features/conftest.py
@@ -6,22 +6,6 @@ from unittest.mock import Mock
 import httpx
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from api.auth.dependencies import AuthDatabaseConnection
-from api.common.dependencies import RequestsClient, SpotifyClientRaw, TokenHolderRaw
-from api.common.models import ParsedTokenResponse
-from api.common.spotify_models import PaginatedSearchResultData, PlaylistTrackData, TrackData
-from api.pool import queue_next_songs
-from api.pool.dependencies import (
-    PoolDatabaseConnectionRaw,
-    PoolPlaybackServiceRaw,
-    PoolSpotifyClientRaw,
-    WebsocketUpdaterRaw,
-)
-from api.pool.models import PoolFullContents, PoolTrack
-from api.pool.randomization_algorithms import NextSongProvider, RandomizationParameters
-from api.pool.spotify_models import PlaybackContextData, PlaybackStateData, QueueData
-from database.database_connection import ConnectionManager
-from database.entities import EntityBase, PlaybackSession, User
 from faker import Faker
 from helpers.classes import CurrentPlaybackData, MockDateTimeWrapper, MockedPlaylistPoolContent, MockedPoolContents
 from sqlalchemy import select
@@ -47,6 +31,23 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.auth.dependencies import AuthDatabaseConnection
+from api.common.dependencies import RequestsClient, SpotifyClientRaw, TokenHolderRaw
+from api.common.models import ParsedTokenResponse
+from api.common.spotify_models import PaginatedSearchResultData, PlaylistTrackData, TrackData
+from api.pool import queue_next_songs
+from api.pool.dependencies import (
+    PoolDatabaseConnectionRaw,
+    PoolPlaybackServiceRaw,
+    PoolSpotifyClientRaw,
+    WebsocketUpdaterRaw,
+)
+from api.pool.models import PoolFullContents, PoolTrack
+from api.pool.randomization_algorithms import NextSongProvider, RandomizationParameters
+from api.pool.spotify_models import PlaybackContextData, PlaybackStateData, QueueData
+from database.database_connection import ConnectionManager
+from database.entities import EntityBase, PlaybackSession, User
 
 
 @pytest.fixture

--- a/server/test/pool_features/create_pool_features.py
+++ b/server/test/pool_features/create_pool_features.py
@@ -1,8 +1,6 @@
 from unittest.mock import Mock, call
 
 import pytest
-from database.database_connection import ConnectionManager
-from database.entities import PoolMember, User
 from helpers.classes import ErrorData, MockedPoolContents
 from sqlalchemy import and_, select
 from sqlalchemy.orm import joinedload
@@ -19,6 +17,9 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from database.database_connection import ConnectionManager
+from database.entities import PoolMember, User
 
 
 @pytest.fixture

--- a/server/test/pool_features/delete_content_features.py
+++ b/server/test/pool_features/delete_content_features.py
@@ -1,10 +1,11 @@
 import pytest
-from database.database_connection import ConnectionManager
-from database.entities import PoolMember, User
 from sqlalchemy import and_, select
 from starlette.testclient import TestClient
 from test_types.callables import AssertTokenInHeaders, CreatePool, GetExistingPool, ValidateResponse
 from test_types.typed_dictionaries import Headers
+
+from database.database_connection import ConnectionManager
+from database.entities import PoolMember, User
 
 
 def should_delete_track_and_return_remaining_pool_if_given_track_id(

--- a/server/test/pool_features/delete_leave_pool_features.py
+++ b/server/test/pool_features/delete_leave_pool_features.py
@@ -2,13 +2,14 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from api.pool.models import PoolFullContents
-from database.database_connection import ConnectionManager
-from database.entities import PlaybackSession, Pool, PoolJoinedUser, PoolMember, User
 from sqlalchemy import select
 from starlette.testclient import TestClient
 from test_types.callables import AssertEmptyPoolModel, AssertEmptyTables, MockPlaylistFetch, ValidateModel
 from test_types.typed_dictionaries import Headers
+
+from api.pool.models import PoolFullContents
+from database.database_connection import ConnectionManager
+from database.entities import PlaybackSession, Pool, PoolJoinedUser, PoolMember, User
 
 
 @pytest.fixture

--- a/server/test/pool_features/get_pool_features.py
+++ b/server/test/pool_features/get_pool_features.py
@@ -1,9 +1,10 @@
 import pytest
-from api.pool.models import PoolFullContents
-from database.entities import PoolMember, User
 from starlette.testclient import TestClient
 from test_types.callables import AssertTokenInHeaders, CreatePool, ValidateErrorResponse, ValidateModel
 from test_types.typed_dictionaries import Headers
+
+from api.pool.models import PoolFullContents
+from database.entities import PoolMember, User
 
 
 def should_get_all_existing_tracks(

--- a/server/test/pool_features/playback_features.py
+++ b/server/test/pool_features/playback_features.py
@@ -3,16 +3,6 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-from api.auth.dependencies import AuthDatabaseConnection
-from api.common.dependencies import TokenHolder
-from api.common.models import ParsedTokenResponse
-from api.common.spotify_models import TrackData
-from api.pool.dependencies import PoolPlaybackServiceRaw
-from api.pool.models import PoolFullContents
-from api.pool.spotify_models import PlaybackContextData
-from api.pool.tasks import queue_next_songs
-from database.database_connection import ConnectionManager
-from database.entities import PlaybackSession, User
 from helpers.classes import ApproxDatetime, MockDateTimeWrapper, MockedPoolContents
 from sqlalchemy import and_, select
 from starlette.testclient import TestClient
@@ -35,6 +25,17 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.auth.dependencies import AuthDatabaseConnection
+from api.common.dependencies import TokenHolder
+from api.common.models import ParsedTokenResponse
+from api.common.spotify_models import TrackData
+from api.pool.dependencies import PoolPlaybackServiceRaw
+from api.pool.models import PoolFullContents
+from api.pool.spotify_models import PlaybackContextData
+from api.pool.tasks import queue_next_songs
+from database.database_connection import ConnectionManager
+from database.entities import PlaybackSession, User
 
 
 @pytest.fixture

--- a/server/test/pool_features/promote_track_features.py
+++ b/server/test/pool_features/promote_track_features.py
@@ -2,11 +2,12 @@ import datetime
 import random
 
 import pytest
-from api.pool.models import PoolFullContents, PoolTrack, UnsavedPoolTrack
 from helpers.classes import CurrentPlaybackData, MockedPoolContents
 from starlette.testclient import TestClient
 from test_types.callables import CreatePool, IncrementNow, MockTrackFetch, RunSchedulingJob, SkipSong, ValidateModel
 from test_types.typed_dictionaries import Headers
+
+from api.pool.models import PoolFullContents, PoolTrack, UnsavedPoolTrack
 
 
 @pytest.fixture

--- a/server/test/pool_features/refresh_token_features.py
+++ b/server/test/pool_features/refresh_token_features.py
@@ -2,8 +2,6 @@ import datetime
 from unittest.mock import Mock
 
 import pytest
-from database.database_connection import ConnectionManager
-from database.entities import UserSession
 from faker import Faker
 from sqlalchemy import select
 from starlette.testclient import TestClient
@@ -17,6 +15,8 @@ from test_types.callables import (
 )
 from test_types.typed_dictionaries import Headers
 
+from database.database_connection import ConnectionManager
+from database.entities import UserSession
 from pool_features.conftest import CreateSpotifyPlayback, RunSchedulingJob
 
 

--- a/server/test/pool_features/shared_pool_features.py
+++ b/server/test/pool_features/shared_pool_features.py
@@ -1,8 +1,6 @@
 from unittest.mock import Mock
 
 import pytest
-from api.pool.models import PoolFullContents
-from database.entities import PoolMember, User
 from helpers.classes import MockedPoolContents
 from starlette.testclient import TestClient
 from test_types.callables import (
@@ -17,6 +15,9 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.pool.models import PoolFullContents
+from database.entities import PoolMember, User
 
 
 @pytest.mark.usefixtures("existing_playback")

--- a/server/test/pool_features/websocket_features.py
+++ b/server/test/pool_features/websocket_features.py
@@ -2,10 +2,6 @@ import datetime
 import random
 
 import pytest
-from api.common.spotify_models import TrackData
-from api.pool import queue_next_songs
-from api.pool.dependencies import PoolPlaybackServiceRaw
-from api.pool.models import PoolFullContents, PoolTrack
 from starlette.testclient import TestClient
 from test_types.callables import (
     BuildQueue,
@@ -19,6 +15,11 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.common.spotify_models import TrackData
+from api.pool import queue_next_songs
+from api.pool.dependencies import PoolPlaybackServiceRaw
+from api.pool.models import PoolFullContents, PoolTrack
 
 
 def should_get_update_when_pool_contents_added(

--- a/server/test/pool_features/weighted_randomization_features.py
+++ b/server/test/pool_features/weighted_randomization_features.py
@@ -4,10 +4,6 @@ from unittest.mock import Mock
 import pytest
 from _pytest.fixtures import FixtureRequest
 from _pytest.monkeypatch import MonkeyPatch
-from api.pool.models import PoolContent, PoolCreationData
-from api.pool.randomization_algorithms import NextSongProvider, RandomizationParameters
-from database.database_connection import ConnectionManager
-from database.entities import PoolJoinedUser, PoolMember, PoolMemberRandomizationParameters, User
 from faker import Faker
 from helpers.classes import CurrentPlaybackData
 from sqlalchemy import select
@@ -30,6 +26,11 @@ from test_types.callables import (
     SkipSong,
 )
 from test_types.typed_dictionaries import Headers, PoolContentData
+
+from api.pool.models import PoolContent, PoolCreationData
+from api.pool.randomization_algorithms import NextSongProvider, RandomizationParameters
+from database.database_connection import ConnectionManager
+from database.entities import PoolJoinedUser, PoolMember, PoolMemberRandomizationParameters, User
 
 
 @pytest.fixture(params=[RandomizationParameters(5, 5, 60, 90), RandomizationParameters(10, 3, 50, 75)])

--- a/server/test/search_features/conftest.py
+++ b/server/test/search_features/conftest.py
@@ -2,8 +2,6 @@ import random
 
 import httpx
 import pytest
-from api.common.spotify_models import PaginatedSearchResultData, SpotifyResourceData
-from api.search.spotify_models import GeneralSearchResultData
 from starlette.testclient import TestClient
 from test_types.aliases import MockResponseQueue
 from test_types.callables import (
@@ -19,6 +17,9 @@ from test_types.callables import (
     ValidatePaginatedResultLength,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.common.spotify_models import PaginatedSearchResultData, SpotifyResourceData
+from api.search.spotify_models import GeneralSearchResultData
 
 
 @pytest.fixture

--- a/server/test/search_features/conftest.py
+++ b/server/test/search_features/conftest.py
@@ -33,10 +33,12 @@ def validate_paginated_result_length() -> ValidatePaginatedResultLength:
 
 @pytest.fixture
 def create_paginated_search_result() -> CreatePaginatedSearchResult:
-    def wrapper[T: SpotifyResourceData](query: str, limit: int, items: list[T]) -> PaginatedSearchResultData[T]:
+    def wrapper[T: SpotifyResourceData](
+        query: str, result_count: int, items: list[T], nulls_appended: int = 0
+    ) -> PaginatedSearchResultData[T]:
         return {
             "href": f"https://api.spotify.com/v1/search?query={query}&type=track&offset=0&limit=20",
-            "limit": limit,
+            "limit": result_count + nulls_appended,
             "next": f"https://api.spotify.com/v1/search?query={query}&type=track&offset=20&limit=20",
             "offset": 0,
             "previous": None,
@@ -54,9 +56,9 @@ def create_album_paginated_search(
     create_mock_artist_search_result: MockArtistSearchResult,
     build_success_response: BuildSuccessResponse,
 ) -> CreateSearchResponse:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
+    def wrapper(query: str, limit: int = 20, nulls_appended: int = 0) -> httpx.Response:
         artists = [create_mock_artist_search_result() for _ in range(limit)]
-        albums = [create_mock_album_search_result(artist) for artist in artists]
+        albums = [create_mock_album_search_result(artist) for artist in artists] + [None for _ in range(nulls_appended)]
         return_json = {"albums": create_paginated_search_result(query, limit, albums)}
         return build_success_response(return_json)
 
@@ -69,8 +71,8 @@ def create_artist_paginated_search(
     create_paginated_search_result: CreatePaginatedSearchResult,
     build_success_response: BuildSuccessResponse,
 ) -> CreateSearchResponse:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
-        artists = [create_mock_artist_search_result() for _ in range(limit)]
+    def wrapper(query: str, limit: int = 20, nulls_appended: int = 0) -> httpx.Response:
+        artists = [create_mock_artist_search_result() for _ in range(limit)] + [None for _ in range(nulls_appended)]
         return_json = {"artists": create_paginated_search_result(query, limit, artists)}
         return build_success_response(return_json)
 
@@ -83,9 +85,11 @@ def create_playlist_paginated_search(
     create_paginated_search_result: CreatePaginatedSearchResult,
     build_success_response: BuildSuccessResponse,
 ) -> CreateSearchResponse:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
-        playlists = [create_mock_playlist_search_result() for _ in range(limit)]
-        return_json = {"playlists": create_paginated_search_result(query, limit, playlists)}
+    def wrapper(query: str, result_count: int = 20, nulls_appended: int = 0) -> httpx.Response:
+        playlists = [create_mock_playlist_search_result() for _ in range(result_count)] + [
+            None for _ in range(nulls_appended)
+        ]
+        return_json = {"playlists": create_paginated_search_result(query, result_count, playlists)}
         return build_success_response(return_json)
 
     return wrapper
@@ -97,8 +101,8 @@ def create_track_paginated_search(
     create_paginated_search_result: CreatePaginatedSearchResult,
     build_success_response: BuildSuccessResponse,
 ) -> CreateSearchResponse:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
-        tracks = [create_mock_track_search_result() for _ in range(limit)]
+    def wrapper(query: str, limit: int = 20, nulls_appended: int = 0) -> httpx.Response:
+        tracks = [create_mock_track_search_result() for _ in range(limit)] + [None for _ in range(nulls_appended)]
         return_json = {"tracks": create_paginated_search_result(query, limit, tracks)}
         return build_success_response(return_json)
 
@@ -113,16 +117,22 @@ def build_spotify_general_search(
     create_mock_track_search_result: MockTrackSearchResult,
     create_paginated_search_result: CreatePaginatedSearchResult,
 ) -> CreateGeneralSearch:
-    def wrapper(query: str, limit: int = 20) -> GeneralSearchResultData:
-        artists = [create_mock_artist_search_result() for _ in range(limit)]
-        tracks = [create_mock_track_search_result() for _ in range(limit)]
-        albums = [create_mock_album_search_result(artist) for artist in artists]
-        playlists = [create_mock_playlist_search_result() for _ in range(limit)]
+    def wrapper(query: str, result_count: int = 20, nulls_appended: int = 0) -> GeneralSearchResultData:
+        artists = [create_mock_artist_search_result() for _ in range(result_count)] + [
+            None for _ in range(nulls_appended)
+        ]
+        tracks = [create_mock_track_search_result() for _ in range(result_count)] + [
+            None for _ in range(nulls_appended)
+        ]
+        albums = [create_mock_album_search_result(artist) for artist in artists] + [None for _ in range(nulls_appended)]
+        playlists = [create_mock_playlist_search_result() for _ in range(result_count)] + [
+            None for _ in range(nulls_appended)
+        ]
         return {
-            "tracks": create_paginated_search_result(query, limit, tracks),
-            "artists": create_paginated_search_result(query, limit, artists),
-            "albums": create_paginated_search_result(query, limit, albums),
-            "playlists": create_paginated_search_result(query, limit, playlists),
+            "tracks": create_paginated_search_result(query, result_count, tracks, nulls_appended),
+            "artists": create_paginated_search_result(query, result_count, artists, nulls_appended),
+            "albums": create_paginated_search_result(query, result_count, albums, nulls_appended),
+            "playlists": create_paginated_search_result(query, result_count, playlists, nulls_appended),
         }
 
     return wrapper
@@ -132,8 +142,8 @@ def build_spotify_general_search(
 def build_spotify_general_search_response(
     build_spotify_general_search: CreateGeneralSearch, build_success_response: BuildSuccessResponse
 ) -> CreateSearchResponse:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
-        return build_success_response(build_spotify_general_search(query, limit))
+    def wrapper(query: str, result_count: int = 20, nulls_appended: int = 0) -> httpx.Response:
+        return build_success_response(build_spotify_general_search(query, result_count, nulls_appended))
 
     return wrapper
 
@@ -143,10 +153,14 @@ def run_search_call(
     test_client: TestClient, valid_token_header: Headers, requests_client_get_queue: MockResponseQueue
 ) -> RunSearchCall:
     def wrapper(
-        query_addition: str | None, response_mocker: CreateSearchResponse, query: str, limit: int = 20
+        query_addition: str | None,
+        response_mocker: CreateSearchResponse,
+        query: str,
+        result_count: int = 20,
+        nulls_appended: int = 0,
     ) -> httpx.Response:
         query_addition = f"/{query_addition}" if query_addition is not None else ""
-        requests_client_get_queue.append(response_mocker(query, limit))
+        requests_client_get_queue.append(response_mocker(query, result_count, nulls_appended))
         return test_client.get(f"/search{query_addition}?query={query}", headers=valid_token_header)
 
     return wrapper

--- a/server/test/search_features/general_search_features.py
+++ b/server/test/search_features/general_search_features.py
@@ -3,8 +3,6 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from api.common.spotify_models import ImageData
-from api.search.models import GeneralSearchResult
 from conftest import ErrorData
 from starlette.testclient import TestClient
 from test_types.aliases import MockResponseQueue
@@ -22,6 +20,9 @@ from test_types.callables import (
     ValidateResponse,
 )
 from test_types.typed_dictionaries import Headers
+
+from api.common.spotify_models import ImageData
+from api.search.models import GeneralSearchResult
 
 
 @pytest.fixture

--- a/server/test/search_features/resource_search_features.py
+++ b/server/test/search_features/resource_search_features.py
@@ -25,11 +25,11 @@ def search_item_type(request: FixtureRequest) -> str:
 def run_search_resource_call(
     request: FixtureRequest, search_item_type: str, run_search_call: RunSearchCall
 ) -> RunSearch:
-    def wrapper(query: str, limit: int = 20) -> httpx.Response:
+    def wrapper(query: str, result_count: int = 20, nulls_appended: int = 0) -> httpx.Response:
         item_query_part: str = f"{search_item_type}s"
         mocker_name = f"create_{search_item_type}_paginated_search"
         mocker_callable: CreateSearchResponse = request.getfixturevalue(mocker_name)
-        return run_search_call(item_query_part, mocker_callable, query, limit)
+        return run_search_call(item_query_part, mocker_callable, query, result_count, nulls_appended)
 
     return wrapper
 
@@ -111,6 +111,19 @@ def should_return_less_results_if_twenty_not_found(
     expected_result_count = 7
     query = "my query"
     result = run_search_resource_call(query, expected_result_count)
+    search_result = validate_response(result)
+    validate_paginated_result_length(search_result, expected_result_count)
+
+
+def should_ignore_trailing_nones_in_item_list(
+    validate_response: ValidateResponse,
+    validate_paginated_result_length: ValidatePaginatedResultLength,
+    run_search_resource_call: RunSearch,
+) -> None:
+    expected_result_count = 10
+    expected_null_count = 10
+    query = "null search"
+    result = run_search_resource_call(query, expected_result_count, expected_null_count)
     search_result = validate_response(result)
     validate_paginated_result_length(search_result, expected_result_count)
 

--- a/server/test/test_types/callables.py
+++ b/server/test/test_types/callables.py
@@ -1,7 +1,11 @@
 import datetime
-from typing import Any, Awaitable, Callable, Protocol
+from collections.abc import Awaitable
+from typing import Any, Callable, Protocol
 
 import httpx
+from helpers.classes import MockedPlaylistPoolContent
+from pydantic import BaseModel
+
 from api.auth.spotify_models import SpotifyFetchMeData
 from api.common.models import ParsedTokenResponse
 from api.common.spotify_models import (
@@ -16,9 +20,6 @@ from api.pool.models import PoolFullContents
 from api.pool.spotify_models import PlaybackContextData, PlaybackStateData, QueueData
 from api.search.spotify_models import GeneralSearchResultData
 from database.entities import EntityBase, PoolMember, User
-from helpers.classes import MockedPlaylistPoolContent
-from pydantic import BaseModel
-
 from test_types.typed_dictionaries import Headers, PoolContentData, PoolCreationDataDict
 
 

--- a/server/test/test_types/callables.py
+++ b/server/test/test_types/callables.py
@@ -91,15 +91,17 @@ class ValidatePaginatedResultLength(Protocol):
 
 
 class CreatePaginatedSearchResult(Protocol):
-    def __call__[T](self, query: str, limit: int, items: list[T]) -> PaginatedSearchResultData[T]: ...
+    def __call__[T](
+        self, query: str, result_count: int, items: list[T], nulls_appended: int = 0
+    ) -> PaginatedSearchResultData[T]: ...
 
 
 class CreateSearchResponse(Protocol):
-    def __call__(self, query: str, limit: int = 20) -> httpx.Response: ...
+    def __call__(self, query: str, result_count: int = 20, nulls_appended: int = 0) -> httpx.Response: ...
 
 
 class RunSearch(Protocol):
-    def __call__(self, query: str, limit: int = 20) -> httpx.Response: ...
+    def __call__(self, query: str, result_count: int = 20, nulls_appended: int = 0) -> httpx.Response: ...
 
 
 class CreateGeneralSearch(Protocol):
@@ -108,7 +110,12 @@ class CreateGeneralSearch(Protocol):
 
 class RunSearchCall(Protocol):
     def __call__(
-        self, query_addition: str | None, search_call: CreateSearchResponse, query: str, limit: int = 20
+        self,
+        query_addition: str | None,
+        search_call: CreateSearchResponse,
+        query: str,
+        result_count: int = 20,
+        nulls_appended: int = 0,
     ) -> httpx.Response: ...
 
 

--- a/server/test_requirements.txt
+++ b/server/test_requirements.txt
@@ -12,5 +12,5 @@ requests==2.31.0
 APScheduler==3.10.4
 Faker==25.0.0
 websockets==12.0
-ruff==0.4.4
+ruff==0.8.4
 pytest-cov==5.0.0


### PR DESCRIPTION
The search routes were only relevant changes found. They now send null objects up to limit given even if no results exist, meaning there were errors in result parsing expecting lists to have no nulls.