### PR TITLE
#447: fix tf error for key already existing

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -81,7 +81,7 @@ module "ec2_instance" {
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t4g.micro"
 
-  key_name                    = "deployer-key"
+  key_name                    = "infra-key"
   monitoring                  = true
   vpc_security_group_ids      = [module.security_group.security_group_id]
   subnet_id                   = element(module.vpc.public_subnets, 0)
@@ -95,11 +95,11 @@ module "ec2_instance" {
   }
 
   tags       = local.tags
-  depends_on = [aws_key_pair.deployer, module.vpc]
+  depends_on = [aws_key_pair.infra, module.vpc]
 }
 
-resource "aws_key_pair" "deployer" {
-  key_name   = "deployer-key"
+resource "aws_key_pair" "infra" {
+  key_name   = "infra-key"
   public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA35JwIz4+3MFomg4fmAK34QYAP/53ip4pYmxXr8yPlV elias.samuli@gmail.com"
 }
 


### PR DESCRIPTION
<!-- Remember to name the pr "#{issue-number} {Name of issue}" -->

## Summary

Fixing this error:
importing EC2 Key Pair (deployer-key): operation error EC2: ImportKeyPair, https response error StatusCode: 400, RequestID: 53d7e269-a3e0-4cec-9e55-33ff6bb69028, api error InvalidKeyPair.Duplicate: The keypair already exists


## Notable changes

<!-- If you made notable changes to architecture, tests, core functionality, etc. please describe them and include
justifications for the changes -->